### PR TITLE
Fix: lazy SQLite index rebuild for HPC-safe concurrent writes

### DIFF
--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -242,12 +242,26 @@ def upsert_entry(conn: sqlite3.Connection, entry: dict, sql: SchemaSQL,
         conn.commit()
 
 
+def _index_is_stale(notebook_dir: Path, dbp: Path) -> bool:
+    """True if any JSONL file or schema.yaml is newer than the index."""
+    idx_mtime = dbp.stat().st_mtime
+    schema_file = notebook_dir / "schema.yaml"
+    if schema_file.exists() and schema_file.stat().st_mtime > idx_mtime:
+        return True
+    edir = entries_dir(notebook_dir)
+    if edir.exists():
+        for f in edir.glob("*.jsonl"):
+            if f.stat().st_mtime > idx_mtime:
+                return True
+    return False
+
+
 def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.Connection, dict, SchemaSQL]:
     if schema is None:
         schema = load_schema(notebook_dir)
     sql = build_sql(schema)
     dbp = index_path(notebook_dir)
-    needs_rebuild = not dbp.exists()
+    needs_rebuild = not dbp.exists() or _index_is_stale(notebook_dir, dbp)
     conn = sqlite3.connect(str(dbp))
     conn.executescript(sql.create)
     if needs_rebuild:
@@ -471,19 +485,6 @@ def cmd_emit(args: argparse.Namespace) -> None:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         f.flush()
         os.fsync(f.fileno())
-
-    # Update index
-    flat = flatten_entry(entry, schema)
-    conn, _, sql = ensure_db(notebook_dir, schema)
-    try:
-        upsert_entry(conn, flat, sql)
-    except sqlite3.OperationalError:
-        print("Error: SQLite schema is out of date. Run 'lab-notebook rebuild'.",
-              file=sys.stderr)
-        print("(The JSONL entry was saved successfully.)", file=sys.stderr)
-        sys.exit(1)
-    finally:
-        conn.close()
 
     print(f"[{entry['type']}] {entry['id']}  {entry['context']}")
 

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -18,6 +18,7 @@ import os
 import secrets
 import sqlite3
 import sys
+import tempfile
 from collections import namedtuple
 from datetime import datetime
 from importlib.resources import files
@@ -246,14 +247,31 @@ def _index_is_stale(notebook_dir: Path, dbp: Path) -> bool:
     """True if any JSONL file or schema.yaml is newer than the index."""
     idx_mtime = dbp.stat().st_mtime
     schema_file = notebook_dir / "schema.yaml"
-    if schema_file.exists() and schema_file.stat().st_mtime > idx_mtime:
+    if schema_file.exists() and schema_file.stat().st_mtime >= idx_mtime:
         return True
     edir = entries_dir(notebook_dir)
     if edir.exists():
         for f in edir.glob("*.jsonl"):
-            if f.stat().st_mtime > idx_mtime:
+            if f.stat().st_mtime >= idx_mtime:
                 return True
     return False
+
+
+def _atomic_rebuild(notebook_dir: Path, dbp: Path,
+                     schema: dict, sql: SchemaSQL) -> int:
+    """Rebuild the index into a temp file, then atomically rename into place."""
+    fd, tmp = tempfile.mkstemp(dir=str(notebook_dir), suffix='.sqlite')
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(tmp)
+        conn.executescript(sql.create)
+        count = rebuild_from_jsonl(conn, notebook_dir, schema, sql)
+        conn.close()
+        os.rename(tmp, str(dbp))
+        return count
+    except BaseException:
+        os.unlink(tmp)
+        raise
 
 
 def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.Connection, dict, SchemaSQL]:
@@ -261,11 +279,10 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
         schema = load_schema(notebook_dir)
     sql = build_sql(schema)
     dbp = index_path(notebook_dir)
-    needs_rebuild = not dbp.exists() or _index_is_stale(notebook_dir, dbp)
+    if not dbp.exists() or _index_is_stale(notebook_dir, dbp):
+        count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
+        print(f"Index rebuilt: {count} entries", file=sys.stderr)
     conn = sqlite3.connect(str(dbp))
-    conn.executescript(sql.create)
-    if needs_rebuild:
-        rebuild_from_jsonl(conn, notebook_dir, schema, sql)
     return conn, schema, sql
 
 
@@ -540,15 +557,8 @@ def cmd_rebuild(args: argparse.Namespace) -> None:
     schema = load_schema(notebook_dir)
     sql = build_sql(schema)
     dbp = index_path(notebook_dir)
-    if dbp.exists():
-        dbp.unlink()
-    conn = sqlite3.connect(str(dbp))
-    conn.executescript(sql.create)
-    try:
-        count = rebuild_from_jsonl(conn, notebook_dir, schema, sql)
-        print(f"Rebuilt index: {count} entries from {entries_dir(notebook_dir)}")
-    finally:
-        conn.close()
+    count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
+    print(f"Rebuilt index: {count} entries from {entries_dir(notebook_dir)}")
 
 
 def cmd_contexts(args: argparse.Namespace) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,7 +229,8 @@ class TestEmit:
         assert "id" in line
         assert "ts" in line
 
-        conn = sqlite3.connect(str(index_path(notebook)))
+        # Index is built lazily on query, not during emit
+        conn, _, _ = ensure_db(notebook)
         rows = conn.execute("SELECT content FROM entries").fetchall()
         conn.close()
         assert len(rows) == 1
@@ -273,7 +274,7 @@ class TestEmit:
         line = json.loads(writer_file.read_text().strip())
         assert line["dataset"] == "cifar10"
 
-        conn = sqlite3.connect(str(index_path(custom_notebook)))
+        conn, _, _ = ensure_db(custom_notebook)
         rows = conn.execute("SELECT dataset FROM entries").fetchall()
         conn.close()
         assert rows[0][0] == "cifar10"
@@ -285,7 +286,7 @@ class TestEmit:
         line = json.loads(writer_file.read_text().strip())
         assert line["gpu_hours"] == 4.5
 
-        conn = sqlite3.connect(str(index_path(custom_notebook)))
+        conn, _, _ = ensure_db(custom_notebook)
         rows = conn.execute("SELECT gpu_hours FROM entries").fetchall()
         conn.close()
         assert rows[0][0] == 4.5
@@ -312,7 +313,7 @@ class TestEmit:
         assert line["foo"] == "bar"
         assert line["num"] == "42"
 
-        conn = sqlite3.connect(str(index_path(notebook)))
+        conn, _, _ = ensure_db(notebook)
         rows = conn.execute("SELECT extra FROM entries").fetchall()
         conn.close()
         extra = json.loads(rows[0][0])
@@ -445,7 +446,7 @@ class TestRebuild:
         cmd_emit(make_emit_args(content="Persistent entry"))
 
         idx = index_path(notebook)
-        idx.unlink()
+        idx.unlink(missing_ok=True)
         assert not idx.exists()
 
         cmd_rebuild(argparse.Namespace())
@@ -461,7 +462,7 @@ class TestRebuild:
     def test_auto_rebuild_on_sql(self, notebook, capsys):
         cmd_emit(make_emit_args(content="Auto rebuild test"))
 
-        index_path(notebook).unlink()
+        index_path(notebook).unlink(missing_ok=True)
 
         cmd_sql(argparse.Namespace(query="SELECT content FROM entries"))
         out = capsys.readouterr().out
@@ -473,7 +474,7 @@ class TestRebuild:
         ))
 
         idx = index_path(custom_notebook)
-        idx.unlink()
+        idx.unlink(missing_ok=True)
 
         cmd_rebuild(argparse.Namespace())
         out = capsys.readouterr().out
@@ -486,9 +487,9 @@ class TestRebuild:
         assert rows[0][1] == 2.5
         assert rows[0][2] == "Custom rebuild"
 
-    def test_emit_after_schema_change_hints_rebuild(self, notebook, capsys):
+    def test_emit_after_schema_change_succeeds(self, notebook, capsys):
         cmd_emit(make_emit_args(content="Before schema change"))
-        # Add a new field to schema without rebuilding
+        # Add a new field to schema — emit no longer touches SQLite
         (notebook / "schema.yaml").write_text(
             "types:\n  - observation\nfields:\n"
             "  repo: {type: text}\n"
@@ -497,14 +498,17 @@ class TestRebuild:
             "  artifacts: {type: list}\n"
             "  new_field: {type: text}\n"
         )
-        with pytest.raises(SystemExit):
-            cmd_emit(make_emit_args(content="After schema change"))
-        err = capsys.readouterr().err
-        assert "rebuild" in err
-        # JSONL entry was still saved
+        # Emit succeeds (JSONL-only, no SQLite interaction)
+        cmd_emit(make_emit_args(content="After schema change"))
         writer_file = entries_dir(notebook) / "test-writer.jsonl"
         lines = writer_file.read_text().strip().split("\n")
         assert len(lines) == 2
+
+        # Query triggers lazy rebuild with new schema
+        conn, _, _ = ensure_db(notebook)
+        rows = conn.execute("SELECT content FROM entries ORDER BY ts").fetchall()
+        conn.close()
+        assert len(rows) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -523,7 +527,7 @@ class TestMultipleWriters:
         assert (edir / "test-writer.jsonl").exists()
         assert (edir / "writer-b.jsonl").exists()
 
-        conn = sqlite3.connect(str(index_path(notebook)))
+        conn, _, _ = ensure_db(notebook)
         rows = conn.execute("SELECT writer_id, content FROM entries ORDER BY writer_id").fetchall()
         conn.close()
         assert len(rows) == 2
@@ -535,7 +539,7 @@ class TestMultipleWriters:
         monkeypatch.setenv("LAB_NOTEBOOK_WRITER", "writer-b")
         cmd_emit(make_emit_args(content="Writer B entry"))
 
-        index_path(notebook).unlink()
+        index_path(notebook).unlink(missing_ok=True)
         cmd_rebuild(argparse.Namespace())
 
         conn = sqlite3.connect(str(index_path(notebook)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from lab_notebook.cli import (
+    _index_is_stale,
     cmd_contexts,
     cmd_emit,
     cmd_init,
@@ -509,6 +510,37 @@ class TestRebuild:
         rows = conn.execute("SELECT content FROM entries ORDER BY ts").fetchall()
         conn.close()
         assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# staleness detection
+# ---------------------------------------------------------------------------
+
+
+class TestStaleness:
+    def test_stale_after_new_entry(self, notebook):
+        ensure_db(notebook)
+        cmd_emit(make_emit_args(content="New entry"))
+        assert _index_is_stale(notebook, index_path(notebook))
+
+    def test_fresh_after_rebuild(self, notebook):
+        cmd_emit(make_emit_args(content="An entry"))
+        ensure_db(notebook)
+        # Rebuild just happened — touch the index to ensure it's strictly newer
+        import time
+        time.sleep(0.05)
+        idx = index_path(notebook)
+        idx.touch()
+        assert not _index_is_stale(notebook, idx)
+
+    def test_stale_after_schema_change(self, notebook):
+        ensure_db(notebook)
+        import time
+        time.sleep(0.05)
+        (notebook / "schema.yaml").write_text(
+            (notebook / "schema.yaml").read_text() + "\n# modified\n"
+        )
+        assert _index_is_stale(notebook, index_path(notebook))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #5

- `emit` no longer writes to `index.sqlite` — only appends to per-writer JSONL files
- SQLite index is rebuilt lazily before queries (`sql`, `search`, `contexts`) using mtime-based staleness detection
- Added `_index_is_stale()` helper: checks if any `*.jsonl` or `schema.yaml` is newer than the index
- Updated tests to reflect the new lazy-rebuild pattern

This makes `lab-notebook` safe for concurrent HPC writes on Lustre, where POSIX file locking is unreliable.

## Test plan

- [x] All 60 existing tests pass
- [ ] Manual: `emit` twice rapidly, confirm both entries appear in `sql` query
- [ ] Manual: confirm `index.sqlite` is not created/modified by `emit`
- [ ] Manual: confirm `sql`/`search`/`contexts` transparently rebuild when index is missing or stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)