### PR TITLE
Add .lnb.env discovery for project-local notebooks

### DIFF
--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -182,15 +182,58 @@ def build_sql(schema: dict) -> SchemaSQL:
 # Helpers
 # ---------------------------------------------------------------------------
 
+LNB_ENV_FILE = ".lnb.env"
+
+
+def _find_lnb_env(start: Path | None = None) -> Path | None:
+    """Walk up from *start* looking for .lnb.env, stop at $HOME or /."""
+    cur = (start or Path.cwd()).resolve()
+    home = Path.home()
+    while True:
+        candidate = cur / LNB_ENV_FILE
+        if candidate.is_file():
+            return candidate
+        if cur == home or cur == cur.parent:
+            return None
+        cur = cur.parent
+
+
+def _parse_lnb_env(env_file: Path) -> str | None:
+    """Extract LAB_NOTEBOOK_DIR value from a .lnb.env file."""
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Strip optional 'export ' prefix
+        if line.startswith("export "):
+            line = line[7:]
+        if line.startswith("LAB_NOTEBOOK_DIR="):
+            val = line.split("=", 1)[1]
+            # Strip surrounding quotes
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                val = val[1:-1]
+            return val
+    return None
+
+
 def get_notebook_dir(hint: str = "") -> Path:
+    # 1. Check for .lnb.env (walk up from CWD)
+    env_file = _find_lnb_env()
+    if env_file:
+        val = _parse_lnb_env(env_file)
+        if val:
+            return Path(val)
+    # 2. Fall back to environment variable
     d = os.environ.get("LAB_NOTEBOOK_DIR")
     if d:
         return Path(d)
-    print("Error: LAB_NOTEBOOK_DIR environment variable is not set.", file=sys.stderr)
+    # 3. Error
+    print("Error: LAB_NOTEBOOK_DIR is not set and no .lnb.env found.", file=sys.stderr)
     if hint:
         print(hint, file=sys.stderr)
     else:
-        print("Run 'lab-notebook init' to create a notebook, then source the .env file.",
+        print("Run 'lab-notebook init --local' to set up a project notebook,\n"
+              "or set $LAB_NOTEBOOK_DIR in your shell profile.",
               file=sys.stderr)
     sys.exit(1)
 
@@ -400,7 +443,15 @@ def cmd_init(args: argparse.Namespace) -> None:
         print_templates()
         return
 
-    target = Path(args.path or ".").resolve()
+    local = getattr(args, "local", False)
+
+    if local:
+        # --local: default notebook path is .lnb in CWD
+        target = Path(args.path or ".lnb").resolve()
+        target.mkdir(parents=True, exist_ok=True)
+    else:
+        target = Path(args.path or ".").resolve()
+
     if not target.exists():
         print(f"Error: directory does not exist: {target}", file=sys.stderr)
         sys.exit(1)
@@ -433,20 +484,39 @@ def cmd_init(args: argparse.Namespace) -> None:
         schema_msg = "already exists (kept)"
 
     writer = os.environ.get("USER", "unknown")
-    env_file = target / ".env"
-    env_file.write_text(
-        f"export LAB_NOTEBOOK_DIR={target}\n"
-        f"export LAB_NOTEBOOK_WRITER={writer}\n"
-    )
 
-    print(f"Initialized lab notebook in {target}")
-    print(f"  entries/       per-writer JSONL files")
-    print(f"  artifacts/     files referenced via --artifacts")
-    print(f"  schema.yaml    {schema_msg}")
-    print(f"  .gitignore     ignores index.sqlite")
-    print(f"  .env           LAB_NOTEBOOK_DIR={target}")
-    print(f"                 LAB_NOTEBOOK_WRITER={writer}")
-    print(f"\nNext: source {env_file}")
+    if local:
+        # Write .lnb.env in CWD (not inside the notebook dir)
+        lnb_env = Path.cwd() / LNB_ENV_FILE
+        lnb_env.write_text(
+            f"# Project-local lab-notebook configuration\n"
+            f"export LAB_NOTEBOOK_DIR={target}\n"
+            f"export LAB_NOTEBOOK_WRITER={writer}\n"
+        )
+        print(f"Initialized lab notebook in {target}")
+        print(f"  entries/       per-writer JSONL files")
+        print(f"  artifacts/     files referenced via --artifacts")
+        print(f"  schema.yaml    {schema_msg}")
+        print(f"  .gitignore     ignores index.sqlite")
+        print(f"\nCreated {lnb_env.name} in {lnb_env.parent}")
+        print(f"  LAB_NOTEBOOK_DIR={target}")
+        print(f"\nConsider adding to .gitignore:")
+        print(f"  {LNB_ENV_FILE}")
+        print(f"  .lnb/")
+    else:
+        env_file = target / ".env"
+        env_file.write_text(
+            f"export LAB_NOTEBOOK_DIR={target}\n"
+            f"export LAB_NOTEBOOK_WRITER={writer}\n"
+        )
+        print(f"Initialized lab notebook in {target}")
+        print(f"  entries/       per-writer JSONL files")
+        print(f"  artifacts/     files referenced via --artifacts")
+        print(f"  schema.yaml    {schema_msg}")
+        print(f"  .gitignore     ignores index.sqlite")
+        print(f"  .env           LAB_NOTEBOOK_DIR={target}")
+        print(f"                 LAB_NOTEBOOK_WRITER={writer}")
+        print(f"\nNext: source {env_file}")
 
 
 def cmd_emit(args: argparse.Namespace) -> None:
@@ -613,6 +683,8 @@ def main() -> None:
     p_init = sub.add_parser("init", help="Initialize a notebook directory")
     p_init.add_argument("path", nargs="?", default=None,
                         help="Directory to initialize (default: current directory)")
+    p_init.add_argument("--local", action="store_true",
+                        help="Create .lnb.env in CWD for project-local notebook (default path: .lnb)")
     p_init.add_argument("--template", nargs="?", const="", default=None,
                         help="Schema template to use (omit value to list available templates)")
     p_init.set_defaults(func=cmd_init)
@@ -627,9 +699,10 @@ def main() -> None:
                         help="Extra undeclared field (repeatable)")
     p_emit.add_argument("content", help="Entry content (notebook prose)")
 
-    # Dynamically add schema-defined fields if LAB_NOTEBOOK_DIR is set
+    # Dynamically add schema-defined fields if a notebook can be found
     _parsed_schema = None
-    notebook_env = os.environ.get("LAB_NOTEBOOK_DIR")
+    env_file = _find_lnb_env()
+    notebook_env = (_parse_lnb_env(env_file) if env_file else None) or os.environ.get("LAB_NOTEBOOK_DIR")
     if notebook_env:
         nb_dir = Path(notebook_env)
         sf = nb_dir / "schema.yaml"

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -488,6 +488,8 @@ def cmd_init(args: argparse.Namespace) -> None:
     if local:
         # Write .lnb.env in CWD (not inside the notebook dir)
         lnb_env = Path.cwd() / LNB_ENV_FILE
+        if lnb_env.exists():
+            print(f"Warning: overwriting existing {lnb_env}", file=sys.stderr)
         lnb_env.write_text(
             f"# Project-local lab-notebook configuration\n"
             f"export LAB_NOTEBOOK_DIR={target}\n"
@@ -699,23 +701,27 @@ def main() -> None:
                         help="Extra undeclared field (repeatable)")
     p_emit.add_argument("content", help="Entry content (notebook prose)")
 
-    # Dynamically add schema-defined fields if a notebook can be found
+    # Dynamically add schema-defined fields if a notebook can be found.
+    # Best-effort: don't crash arg parsing if the path is stale or schema is bad.
     _parsed_schema = None
-    env_file = _find_lnb_env()
-    notebook_env = (_parse_lnb_env(env_file) if env_file else None) or os.environ.get("LAB_NOTEBOOK_DIR")
-    if notebook_env:
-        nb_dir = Path(notebook_env)
-        sf = nb_dir / "schema.yaml"
-        if sf.exists():
-            _parsed_schema = load_schema(nb_dir)
-            for name, spec in _parsed_schema.get("fields", {}).items():
-                if name in BUILTIN_FIELDS:
-                    continue  # already added as a static argument
-                ftype = spec.get("type", "text")
-                help_text = f"Schema field ({ftype})"
-                if ftype == "list":
-                    help_text = f"Schema field ({ftype}, comma-separated)"
-                p_emit.add_argument(f"--{name}", default=None, help=help_text)
+    try:
+        env_file = _find_lnb_env()
+        notebook_env = (_parse_lnb_env(env_file) if env_file else None) or os.environ.get("LAB_NOTEBOOK_DIR")
+        if notebook_env:
+            nb_dir = Path(notebook_env)
+            sf = nb_dir / "schema.yaml"
+            if sf.exists():
+                _parsed_schema = load_schema(nb_dir)
+                for name, spec in _parsed_schema.get("fields", {}).items():
+                    if name in BUILTIN_FIELDS:
+                        continue  # already added as a static argument
+                    ftype = spec.get("type", "text")
+                    help_text = f"Schema field ({ftype})"
+                    if ftype == "list":
+                        help_text = f"Schema field ({ftype}, comma-separated)"
+                    p_emit.add_argument(f"--{name}", default=None, help=help_text)
+    except (SystemExit, Exception):
+        pass  # schema loading failed — emit will load schema at runtime
 
     p_emit.set_defaults(func=cmd_emit, _schema=_parsed_schema)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,10 @@ from pathlib import Path
 import pytest
 
 from lab_notebook.cli import (
+    LNB_ENV_FILE,
+    _find_lnb_env,
     _index_is_stale,
+    _parse_lnb_env,
     cmd_contexts,
     cmd_emit,
     cmd_init,
@@ -21,6 +24,7 @@ from lab_notebook.cli import (
     cmd_template,
     ensure_db,
     entries_dir,
+    get_notebook_dir,
     get_template_path,
     index_path,
     list_templates,
@@ -780,3 +784,129 @@ class TestInitTemplate:
         cmd_init(args)
         out = capsys.readouterr().out
         assert "overwritten" in out
+
+
+# ---------------------------------------------------------------------------
+# .lnb.env discovery tests
+# ---------------------------------------------------------------------------
+
+
+class TestLnbEnvDiscovery:
+    """Tests for .lnb.env file discovery and parsing."""
+
+    def test_find_lnb_env_in_cwd(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(f"export LAB_NOTEBOOK_DIR={tmp_path}/nb\n")
+        result = _find_lnb_env(start=tmp_path)
+        assert result == env_file
+
+    def test_find_lnb_env_walk_up(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(f"export LAB_NOTEBOOK_DIR={tmp_path}/nb\n")
+        subdir = tmp_path / "a" / "b"
+        subdir.mkdir(parents=True)
+        result = _find_lnb_env(start=subdir)
+        assert result == env_file
+
+    def test_find_lnb_env_not_found(self, tmp_path):
+        result = _find_lnb_env(start=tmp_path)
+        assert result is None
+
+    def test_parse_lnb_env_basic(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text("export LAB_NOTEBOOK_DIR=/some/path\n")
+        assert _parse_lnb_env(env_file) == "/some/path"
+
+    def test_parse_lnb_env_quoted(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text('export LAB_NOTEBOOK_DIR="/some/path"\n')
+        assert _parse_lnb_env(env_file) == "/some/path"
+
+    def test_parse_lnb_env_no_export(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text("LAB_NOTEBOOK_DIR=/some/path\n")
+        assert _parse_lnb_env(env_file) == "/some/path"
+
+    def test_parse_lnb_env_with_comments(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(
+            "# Project notebook config\n"
+            "export LAB_NOTEBOOK_DIR=/some/path\n"
+            "export LAB_NOTEBOOK_WRITER=alice\n"
+        )
+        assert _parse_lnb_env(env_file) == "/some/path"
+
+    def test_parse_lnb_env_empty_file(self, tmp_path):
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text("")
+        assert _parse_lnb_env(env_file) is None
+
+    def test_get_notebook_dir_from_lnb_env(self, tmp_path, monkeypatch):
+        nb_dir = tmp_path / "nb"
+        nb_dir.mkdir()
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(f"export LAB_NOTEBOOK_DIR={nb_dir}\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LAB_NOTEBOOK_DIR", raising=False)
+        assert get_notebook_dir() == nb_dir
+
+    def test_get_notebook_dir_env_fallback(self, tmp_path, monkeypatch):
+        nb_dir = tmp_path / "nb"
+        nb_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(nb_dir))
+        # No .lnb.env — should fall back to env var
+        assert get_notebook_dir() == nb_dir
+
+    def test_get_notebook_dir_lnb_env_precedence(self, tmp_path, monkeypatch):
+        local_nb = tmp_path / "local-nb"
+        local_nb.mkdir()
+        global_nb = tmp_path / "global-nb"
+        global_nb.mkdir()
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(f"export LAB_NOTEBOOK_DIR={local_nb}\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(global_nb))
+        # .lnb.env should win over $LAB_NOTEBOOK_DIR
+        assert get_notebook_dir() == local_nb
+
+
+class TestInitLocal:
+    """Tests for lab-notebook init --local."""
+
+    def test_init_local_creates_lnb_env(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(path=None, template=None, local=True)
+        cmd_init(args)
+        lnb_env = tmp_path / LNB_ENV_FILE
+        assert lnb_env.exists()
+        content = lnb_env.read_text()
+        assert "LAB_NOTEBOOK_DIR=" in content
+        assert ".lnb" in content
+
+    def test_init_local_creates_notebook_dir(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(path=None, template=None, local=True)
+        cmd_init(args)
+        nb_dir = tmp_path / ".lnb"
+        assert nb_dir.is_dir()
+        assert (nb_dir / "schema.yaml").exists()
+        assert (nb_dir / "entries").is_dir()
+
+    def test_init_local_custom_path(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(path="my-notebook", template=None, local=True)
+        cmd_init(args)
+        nb_dir = tmp_path / "my-notebook"
+        assert nb_dir.is_dir()
+        lnb_env = tmp_path / LNB_ENV_FILE
+        content = lnb_env.read_text()
+        assert str(nb_dir) in content
+
+    def test_init_without_local_unchanged(self, tmp_path, capsys):
+        """Regular init (no --local) still works as before."""
+        args = argparse.Namespace(path=str(tmp_path), template=None, local=False)
+        cmd_init(args)
+        # Should create .env inside the notebook dir, not .lnb.env
+        assert (tmp_path / ".env").exists()
+        assert not (tmp_path / LNB_ENV_FILE).exists()


### PR DESCRIPTION
## Summary
- `get_notebook_dir()` now walks up from CWD looking for `.lnb.env` before falling back to `$LAB_NOTEBOOK_DIR`
- New `lab-notebook init --local` flag creates `.lnb.env` in CWD with default notebook path `.lnb/`
- Dynamic schema field loading at parse time also checks `.lnb.env`

## Motivation
Previously, project-local notebooks required the skill (SKILL.md) to `source .lnb.env` before calling the CLI. This moves resolution into the CLI itself so that **all consumers** (skill, shell, scripts) get project-local notebooks automatically — matching how `git` finds `.git/`, `cargo` finds `Cargo.toml`, etc.

## Test plan
- [x] All 82 tests pass (`uv run pytest`)
- [ ] `lab-notebook init --local` in a project dir creates `.lnb.env` + `.lnb/`
- [ ] `lab-notebook schema` from a subdirectory finds `.lnb.env` in parent via walk-up
- [ ] `.lnb.env` takes precedence over `$LAB_NOTEBOOK_DIR` when both are set
- [ ] Regular `lab-notebook init` (no `--local`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)