### PR TITLE
Make project-local init the default, remove --local flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ uv tool install --force git+https://github.com/carbonscott/lab-notebook
 ## Quick Start
 
 ```bash
-# 1. Create a notebook directory and initialize it
-mkdir /path/to/my-notebook
-lab-notebook init /path/to/my-notebook
+# 1. Initialize a project-local notebook (creates .lnb/ and .lnb.env)
+cd /path/to/my-project
+lab-notebook init
 
-# 2. Source the .env (sets LAB_NOTEBOOK_DIR and LAB_NOTEBOOK_WRITER)
-source /path/to/my-notebook/.env
+# 2. Source .lnb.env (sets LAB_NOTEBOOK_DIR and LAB_NOTEBOOK_WRITER)
+source .lnb.env
 
 # 3. Write an entry (CLI args come from schema.yaml)
 lab-notebook emit --context maxie/ssl-comparison --type observation \
@@ -98,10 +98,12 @@ Run `lab-notebook rebuild` after changing `schema.yaml`.
 
 ### `init [path] [--template NAME]`
 
-Initialize a notebook in an existing directory (default: cwd). Creates
-`entries/`, `artifacts/`, `schema.yaml`, `.gitignore`, and `.env`. Use `--template` to pick
-a schema template (default: `research-notebook`). Pass `--template` with no
-value to list available templates.
+Initialize a project-local notebook. Creates `.lnb/` in the current directory
+(or at `path` if given) with `entries/`, `artifacts/`, `schema.yaml`, and
+`.gitignore`. Also writes `.lnb.env` in the current directory for automatic
+notebook discovery. Use `--template` to pick a schema template (default:
+`research-notebook`). Pass `--template` with no value to list available
+templates.
 
 ### `emit --context X --type Y [--artifacts ...] [--field ...] [--extra K=V] "content"`
 
@@ -138,16 +140,17 @@ Run `lab-notebook rebuild` afterward if entries exist.
 ## Data Layout
 
 ```
-my-notebook/
-├── entries/
-│   ├── cong.jsonl
-│   ├── intern-alice.jsonl
-│   └── agent-claude-01.jsonl
-├── artifacts/        # tracked; store files referenced via --artifacts
-├── schema.yaml       # field definitions and entry types
-├── index.sqlite      # gitignored, rebuilt on demand
-├── .gitignore
-└── .env
+my-project/
+├── .lnb/
+│   ├── entries/
+│   │   ├── cong.jsonl
+│   │   ├── intern-alice.jsonl
+│   │   └── agent-claude-01.jsonl
+│   ├── artifacts/        # tracked; store files referenced via --artifacts
+│   ├── schema.yaml       # field definitions and entry types
+│   ├── index.sqlite      # gitignored, rebuilt on demand
+│   └── .gitignore
+└── .lnb.env              # points to .lnb/, source this
 ```
 
 Each writer gets their own JSONL file. No merge conflicts.

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -490,7 +490,7 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"  LAB_NOTEBOOK_DIR={target}")
     print(f"\nConsider adding to .gitignore:")
     print(f"  {LNB_ENV_FILE}")
-    print(f"  .lnb/")
+    print(f"  {target.name}/")
 
 
 def cmd_emit(args: argparse.Namespace) -> None:
@@ -656,7 +656,7 @@ def main() -> None:
     # -- init --
     p_init = sub.add_parser("init", help="Initialize a notebook directory")
     p_init.add_argument("path", nargs="?", default=None,
-                        help="Notebook directory (default: .lnb in current directory)")
+                        help="Notebook root directory (default: .lnb in current directory)")
     p_init.add_argument("--template", nargs="?", const="", default=None,
                         help="Schema template to use (omit value to list available templates)")
     p_init.set_defaults(func=cmd_init)

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -232,7 +232,7 @@ def get_notebook_dir(hint: str = "") -> Path:
     if hint:
         print(hint, file=sys.stderr)
     else:
-        print("Run 'lab-notebook init --local' to set up a project notebook,\n"
+        print("Run 'lab-notebook init' to set up a project notebook,\n"
               "or set $LAB_NOTEBOOK_DIR in your shell profile.",
               file=sys.stderr)
     sys.exit(1)
@@ -443,21 +443,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         print_templates()
         return
 
-    local = getattr(args, "local", False)
-
-    if local:
-        # --local: default notebook path is .lnb in CWD
-        target = Path(args.path or ".lnb").resolve()
-        target.mkdir(parents=True, exist_ok=True)
-    else:
-        target = Path(args.path or ".").resolve()
-
-    if not target.exists():
-        print(f"Error: directory does not exist: {target}", file=sys.stderr)
-        sys.exit(1)
-    if not target.is_dir():
-        print(f"Error: not a directory: {target}", file=sys.stderr)
-        sys.exit(1)
+    target = Path(args.path or ".lnb").resolve()
+    target.mkdir(parents=True, exist_ok=True)
 
     template_name = getattr(args, "template", None) or DEFAULT_TEMPLATE
 
@@ -485,40 +472,25 @@ def cmd_init(args: argparse.Namespace) -> None:
 
     writer = os.environ.get("USER", "unknown")
 
-    if local:
-        # Write .lnb.env in CWD (not inside the notebook dir)
-        lnb_env = Path.cwd() / LNB_ENV_FILE
-        if lnb_env.exists():
-            print(f"Warning: overwriting existing {lnb_env}", file=sys.stderr)
-        lnb_env.write_text(
-            f"# Project-local lab-notebook configuration\n"
-            f"export LAB_NOTEBOOK_DIR={target}\n"
-            f"export LAB_NOTEBOOK_WRITER={writer}\n"
-        )
-        print(f"Initialized lab notebook in {target}")
-        print(f"  entries/       per-writer JSONL files")
-        print(f"  artifacts/     files referenced via --artifacts")
-        print(f"  schema.yaml    {schema_msg}")
-        print(f"  .gitignore     ignores index.sqlite")
-        print(f"\nCreated {lnb_env.name} in {lnb_env.parent}")
-        print(f"  LAB_NOTEBOOK_DIR={target}")
-        print(f"\nConsider adding to .gitignore:")
-        print(f"  {LNB_ENV_FILE}")
-        print(f"  .lnb/")
-    else:
-        env_file = target / ".env"
-        env_file.write_text(
-            f"export LAB_NOTEBOOK_DIR={target}\n"
-            f"export LAB_NOTEBOOK_WRITER={writer}\n"
-        )
-        print(f"Initialized lab notebook in {target}")
-        print(f"  entries/       per-writer JSONL files")
-        print(f"  artifacts/     files referenced via --artifacts")
-        print(f"  schema.yaml    {schema_msg}")
-        print(f"  .gitignore     ignores index.sqlite")
-        print(f"  .env           LAB_NOTEBOOK_DIR={target}")
-        print(f"                 LAB_NOTEBOOK_WRITER={writer}")
-        print(f"\nNext: source {env_file}")
+    # Write .lnb.env in CWD
+    lnb_env = Path.cwd() / LNB_ENV_FILE
+    if lnb_env.exists():
+        print(f"Warning: overwriting existing {lnb_env}", file=sys.stderr)
+    lnb_env.write_text(
+        f"# Project-local lab-notebook configuration\n"
+        f"export LAB_NOTEBOOK_DIR={target}\n"
+        f"export LAB_NOTEBOOK_WRITER={writer}\n"
+    )
+    print(f"Initialized lab notebook in {target}")
+    print(f"  entries/       per-writer JSONL files")
+    print(f"  artifacts/     files referenced via --artifacts")
+    print(f"  schema.yaml    {schema_msg}")
+    print(f"  .gitignore     ignores index.sqlite")
+    print(f"\nCreated {lnb_env.name} in {lnb_env.parent}")
+    print(f"  LAB_NOTEBOOK_DIR={target}")
+    print(f"\nConsider adding to .gitignore:")
+    print(f"  {LNB_ENV_FILE}")
+    print(f"  .lnb/")
 
 
 def cmd_emit(args: argparse.Namespace) -> None:
@@ -684,9 +656,7 @@ def main() -> None:
     # -- init --
     p_init = sub.add_parser("init", help="Initialize a notebook directory")
     p_init.add_argument("path", nargs="?", default=None,
-                        help="Directory to initialize (default: current directory)")
-    p_init.add_argument("--local", action="store_true",
-                        help="Create .lnb.env in CWD for project-local notebook (default path: .lnb)")
+                        help="Notebook directory (default: .lnb in current directory)")
     p_init.add_argument("--template", nargs="?", const="", default=None,
                         help="Schema template to use (omit value to list available templates)")
     p_init.set_defaults(func=cmd_init)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,6 +159,7 @@ class TestInit:
         cmd_init(args)
         assert target.is_dir()
         assert (target / "entries").is_dir()
+        assert (tmp_path / LNB_ENV_FILE).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,8 +39,8 @@ from lab_notebook.cli import (
 @pytest.fixture()
 def notebook(tmp_path, monkeypatch):
     """Initialize a notebook in a temp directory and set env vars."""
+    monkeypatch.chdir(tmp_path)
     target = tmp_path / "nb"
-    target.mkdir()
     args = argparse.Namespace(path=str(target), template=None)
     cmd_init(args)
     monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(target))
@@ -51,8 +51,8 @@ def notebook(tmp_path, monkeypatch):
 @pytest.fixture()
 def custom_notebook(tmp_path, monkeypatch):
     """Initialize a notebook with a custom schema."""
+    monkeypatch.chdir(tmp_path)
     target = tmp_path / "nb"
-    target.mkdir()
     args = argparse.Namespace(path=str(target), template=None)
     cmd_init(args)
     # Overwrite schema.yaml with custom fields
@@ -110,9 +110,9 @@ def make_custom_emit_args(**kwargs):
 
 
 class TestInit:
-    def test_creates_structure(self, tmp_path):
+    def test_creates_structure(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         args = argparse.Namespace(path=str(target), template=None)
         cmd_init(args)
 
@@ -120,14 +120,16 @@ class TestInit:
         assert (target / "artifacts").is_dir()
         assert (target / ".gitignore").exists()
         assert "index.sqlite" in (target / ".gitignore").read_text()
-        assert (target / ".env").exists()
-        env_text = (target / ".env").read_text()
+        # .lnb.env written in CWD
+        lnb_env = tmp_path / LNB_ENV_FILE
+        assert lnb_env.exists()
+        env_text = lnb_env.read_text()
         assert f"LAB_NOTEBOOK_DIR={target}" in env_text
         assert "LAB_NOTEBOOK_WRITER=" in env_text
 
-    def test_init_creates_schema_yaml(self, tmp_path):
+    def test_init_creates_schema_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         args = argparse.Namespace(path=str(target), template=None)
         cmd_init(args)
 
@@ -145,14 +147,18 @@ class TestInit:
         args = argparse.Namespace(path=None, template=None)
         cmd_init(args)
 
-        assert (tmp_path / "entries").is_dir()
-        assert (tmp_path / ".env").exists()
-        assert (tmp_path / "schema.yaml").exists()
+        # Default creates .lnb/ and .lnb.env
+        assert (tmp_path / ".lnb" / "entries").is_dir()
+        assert (tmp_path / ".lnb" / "schema.yaml").exists()
+        assert (tmp_path / LNB_ENV_FILE).exists()
 
-    def test_init_nonexistent_dir(self, tmp_path):
-        args = argparse.Namespace(path=str(tmp_path / "does-not-exist"), template=None)
-        with pytest.raises(SystemExit):
-            cmd_init(args)
+    def test_init_auto_creates_dir(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "new-notebook"
+        args = argparse.Namespace(path=str(target), template=None)
+        cmd_init(args)
+        assert target.is_dir()
+        assert (target / "entries").is_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -720,9 +726,9 @@ class TestCmdTemplate:
 
 
 class TestInitTemplate:
-    def test_init_with_template(self, tmp_path):
+    def test_init_with_template(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         args = argparse.Namespace(path=str(target), template="ml-experiment-log")
         cmd_init(args)
         import yaml
@@ -737,9 +743,9 @@ class TestInitTemplate:
         assert "research-notebook" in out
         assert "ml-experiment-log" in out
 
-    def test_init_template_overwrites_existing(self, tmp_path):
+    def test_init_template_overwrites_existing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         # First init with default
         args = argparse.Namespace(path=str(target), template=None)
         cmd_init(args)
@@ -752,9 +758,9 @@ class TestInitTemplate:
         schema = yaml.safe_load((target / "schema.yaml").read_text())
         assert "run-start" in schema["types"]
 
-    def test_init_no_template_keeps_existing(self, tmp_path):
+    def test_init_no_template_keeps_existing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         args = argparse.Namespace(path=str(target), template=None)
         cmd_init(args)
         # Overwrite schema with custom content
@@ -766,9 +772,9 @@ class TestInitTemplate:
         schema = yaml.safe_load((target / "schema.yaml").read_text())
         assert "custom" in schema["types"]
 
-    def test_init_output_reflects_reality(self, tmp_path, capsys):
+    def test_init_output_reflects_reality(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
         target = tmp_path / "nb"
-        target.mkdir()
         # First init
         args = argparse.Namespace(path=str(target), template=None)
         cmd_init(args)
@@ -871,12 +877,12 @@ class TestLnbEnvDiscovery:
         assert get_notebook_dir() == local_nb
 
 
-class TestInitLocal:
-    """Tests for lab-notebook init --local."""
+class TestInitDefault:
+    """Tests for lab-notebook init (always creates .lnb/ + .lnb.env)."""
 
-    def test_init_local_creates_lnb_env(self, tmp_path, monkeypatch, capsys):
+    def test_init_creates_lnb_env(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        args = argparse.Namespace(path=None, template=None, local=True)
+        args = argparse.Namespace(path=None, template=None)
         cmd_init(args)
         lnb_env = tmp_path / LNB_ENV_FILE
         assert lnb_env.exists()
@@ -884,29 +890,22 @@ class TestInitLocal:
         assert "LAB_NOTEBOOK_DIR=" in content
         assert ".lnb" in content
 
-    def test_init_local_creates_notebook_dir(self, tmp_path, monkeypatch, capsys):
+    def test_init_creates_notebook_dir(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        args = argparse.Namespace(path=None, template=None, local=True)
+        args = argparse.Namespace(path=None, template=None)
         cmd_init(args)
         nb_dir = tmp_path / ".lnb"
         assert nb_dir.is_dir()
         assert (nb_dir / "schema.yaml").exists()
         assert (nb_dir / "entries").is_dir()
+        assert (nb_dir / "artifacts").is_dir()
 
-    def test_init_local_custom_path(self, tmp_path, monkeypatch, capsys):
+    def test_init_custom_path(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        args = argparse.Namespace(path="my-notebook", template=None, local=True)
+        args = argparse.Namespace(path="my-notebook", template=None)
         cmd_init(args)
         nb_dir = tmp_path / "my-notebook"
         assert nb_dir.is_dir()
         lnb_env = tmp_path / LNB_ENV_FILE
         content = lnb_env.read_text()
         assert str(nb_dir) in content
-
-    def test_init_without_local_unchanged(self, tmp_path, capsys):
-        """Regular init (no --local) still works as before."""
-        args = argparse.Namespace(path=str(tmp_path), template=None, local=False)
-        cmd_init(args)
-        # Should create .env inside the notebook dir, not .lnb.env
-        assert (tmp_path / ".env").exists()
-        assert not (tmp_path / LNB_ENV_FILE).exists()


### PR DESCRIPTION
## Summary

Closes #12

- `lab-notebook init` now always creates `.lnb/` + `.lnb.env` in the current directory (previously required `--local`)
- `lab-notebook init <path>` creates the notebook at `<path>` + `.lnb.env` in CWD
- Removed `--local` flag and the old non-local code path (`.env` inside notebook dir)
- Updated tests and README to match

## Test plan

- [x] All 81 tests pass (`uv run pytest tests/test_cli.py -v`)
- [x] Smoke test: `lab-notebook init` creates `.lnb/` with `entries/`, `artifacts/`, `schema.yaml`, `.gitignore`
- [x] Smoke test: `.lnb.env` written to CWD with correct `LAB_NOTEBOOK_DIR`
- [ ] Verify `source .lnb.env && lab-notebook schema` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)