### PR TITLE
fix: honor explicit $LAB_NOTEBOOK_DIR over .lnb.env auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ lab-notebook search "masking"
 | `LAB_NOTEBOOK_DIR` | Yes | — | Path to notebook data directory |
 | `LAB_NOTEBOOK_WRITER` | No | `$USER` | Writer ID for entries |
 
+### Notebook discovery precedence
+
+When the CLI resolves which notebook to use, it checks sources in this order
+(first match wins):
+
+1. `$LAB_NOTEBOOK_DIR` environment variable (if set and non-empty)
+2. Nearest `.lnb.env` walking up from the current directory (closest wins,
+   stops at `$HOME` or `/`)
+
+Explicit `LAB_NOTEBOOK_DIR=... lab-notebook ...` always wins, so one-shot
+overrides work as expected. For normal project use, `source .lnb.env` after
+`cd`ing into a project so the env var is set for your shell.
+
 ## Schema Configuration
 
 Each notebook has a `schema.yaml` that defines entry types and custom fields.

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -217,23 +217,23 @@ def _parse_lnb_env(env_file: Path) -> str | None:
 
 
 def get_notebook_dir(hint: str = "") -> Path:
-    # 1. Check for .lnb.env (walk up from CWD)
+    # 1. Explicit $LAB_NOTEBOOK_DIR wins (standard Unix precedence)
+    d = os.environ.get("LAB_NOTEBOOK_DIR")
+    if d:
+        return Path(d)
+    # 2. Fall back to nearest .lnb.env walking up from CWD
     env_file = _find_lnb_env()
     if env_file:
         val = _parse_lnb_env(env_file)
         if val:
             return Path(val)
-    # 2. Fall back to environment variable
-    d = os.environ.get("LAB_NOTEBOOK_DIR")
-    if d:
-        return Path(d)
     # 3. Error
     print("Error: LAB_NOTEBOOK_DIR is not set and no .lnb.env found.", file=sys.stderr)
     if hint:
         print(hint, file=sys.stderr)
     else:
-        print("Run 'lab-notebook init' to set up a project notebook,\n"
-              "or set $LAB_NOTEBOOK_DIR in your shell profile.",
+        print("Set $LAB_NOTEBOOK_DIR, or run 'lab-notebook init' to create\n"
+              "a project-local notebook (writes .lnb.env in the current directory).",
               file=sys.stderr)
     sys.exit(1)
 
@@ -706,8 +706,10 @@ def main() -> None:
     # Best-effort: don't crash arg parsing if the path is stale or schema is bad.
     _parsed_schema = None
     try:
-        env_file = _find_lnb_env()
-        notebook_env = (_parse_lnb_env(env_file) if env_file else None) or os.environ.get("LAB_NOTEBOOK_DIR")
+        notebook_env = os.environ.get("LAB_NOTEBOOK_DIR")
+        if not notebook_env:
+            env_file = _find_lnb_env()
+            notebook_env = _parse_lnb_env(env_file) if env_file else None
         if notebook_env:
             nb_dir = Path(notebook_env)
             sf = nb_dir / "schema.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -945,17 +945,27 @@ class TestLnbEnvDiscovery:
         # No .lnb.env — should fall back to env var
         assert get_notebook_dir() == nb_dir
 
-    def test_get_notebook_dir_lnb_env_precedence(self, tmp_path, monkeypatch):
+    def test_get_notebook_dir_env_var_precedence(self, tmp_path, monkeypatch):
         local_nb = tmp_path / "local-nb"
         local_nb.mkdir()
-        global_nb = tmp_path / "global-nb"
-        global_nb.mkdir()
+        explicit_nb = tmp_path / "explicit-nb"
+        explicit_nb.mkdir()
         env_file = tmp_path / LNB_ENV_FILE
         env_file.write_text(f"export LAB_NOTEBOOK_DIR={local_nb}\n")
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(global_nb))
-        # .lnb.env should win over $LAB_NOTEBOOK_DIR
-        assert get_notebook_dir() == local_nb
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(explicit_nb))
+        # $LAB_NOTEBOOK_DIR should win over .lnb.env
+        assert get_notebook_dir() == explicit_nb
+
+    def test_get_notebook_dir_empty_env_var_falls_through(self, tmp_path, monkeypatch):
+        nb_dir = tmp_path / "nb"
+        nb_dir.mkdir()
+        env_file = tmp_path / LNB_ENV_FILE
+        env_file.write_text(f"export LAB_NOTEBOOK_DIR={nb_dir}\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", "")
+        # Empty env var should be treated as unset; .lnb.env wins
+        assert get_notebook_dir() == nb_dir
 
 
 class TestInitDefault:


### PR DESCRIPTION
## Summary

- Fixes #17. `get_notebook_dir()` used to resolve `.lnb.env` (walked upward from CWD) before `$LAB_NOTEBOOK_DIR`, so `LAB_NOTEBOOK_DIR=/sandbox/.lnb lab-notebook sql ...` silently ran against a different notebook whenever any parent directory had a `.lnb.env`.
- Flips precedence to the standard Unix order: explicit env var wins, `.lnb.env` walk-up only fills in when the env var is unset. Empty-string env var is treated as unset (falls through).
- Same swap applied to the best-effort schema lookup in `cmd_emit` so `--<field>` argparse options stay consistent with the resolved notebook.

## Test plan

- [x] `uv run pytest tests/test_cli.py -v` — 90 passed, including renamed `test_get_notebook_dir_env_var_precedence` (flipped assertion) and new `test_get_notebook_dir_empty_env_var_falls_through`.
- [x] Manual repro from issue #17: outer notebook at `/tmp/lnb-outer/.lnb`, inner sandbox at `/tmp/lnb-outer/sub/sandbox/.lnb` with a distinct entry. From `/tmp/lnb-outer/sub/` (where walk-up hits the outer `.lnb.env`):
  - `LAB_NOTEBOOK_DIR=.../sandbox/.lnb lab-notebook sql "..."` → returns sandbox entry. ✅
  - Without env var → falls through to walk-up, returns outer notebook. ✅
- [ ] README note on precedence renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
