### PR TITLE
feat: incremental ingest via per-file byte offsets

### DIFF
--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -299,20 +299,6 @@ def upsert_entry(conn: sqlite3.Connection, entry: dict, sql: SchemaSQL,
         conn.commit()
 
 
-def _index_is_stale(notebook_dir: Path, dbp: Path) -> bool:
-    """True if any JSONL file or schema.yaml is newer than the index."""
-    idx_mtime = dbp.stat().st_mtime
-    schema_file = notebook_dir / "schema.yaml"
-    if schema_file.exists() and schema_file.stat().st_mtime >= idx_mtime:
-        return True
-    edir = entries_dir(notebook_dir)
-    if edir.exists():
-        for f in edir.glob("*.jsonl"):
-            if f.stat().st_mtime >= idx_mtime:
-                return True
-    return False
-
-
 def _atomic_rebuild(notebook_dir: Path, dbp: Path,
                      schema: dict, sql: SchemaSQL) -> int:
     """Rebuild the index into a temp file, then atomically rename into place."""
@@ -418,18 +404,21 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
         print(f"Index rebuilt: {count} entries", file=sys.stderr)
     else:
         conn = sqlite3.connect(str(dbp))
+        fence_tripped = None
+        new_count = 0
         try:
             new_count = incremental_ingest(conn, notebook_dir, schema, sql)
         except _IngestFenceTripped as e:
+            fence_tripped = str(e)
+        finally:
             conn.close()
-            print(f"Ingest fence tripped on {e}; falling back to full rebuild",
-                  file=sys.stderr)
+        if fence_tripped is not None:
+            print(f"Ingest fence tripped on {fence_tripped}; "
+                  f"falling back to full rebuild", file=sys.stderr)
             count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
             print(f"Index rebuilt: {count} entries", file=sys.stderr)
-        else:
-            conn.close()
-            if new_count:
-                print(f"Index updated: +{new_count} entries", file=sys.stderr)
+        elif new_count:
+            print(f"Index updated: +{new_count} entries", file=sys.stderr)
     conn = sqlite3.connect(str(dbp))
     return conn, schema, sql
 

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -153,6 +153,8 @@ def build_sql(schema: dict) -> SchemaSQL:
         + "CREATE INDEX IF NOT EXISTS idx_entries_context ON entries(context);\n"
         + "CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);\n"
         + "CREATE INDEX IF NOT EXISTS idx_entries_ts ON entries(ts);\n"
+        + "CREATE TABLE IF NOT EXISTS _ingest_state ("
+        + "file TEXT PRIMARY KEY, offset INTEGER NOT NULL);\n"
     )
 
     # -- UPSERT --
@@ -328,43 +330,126 @@ def _atomic_rebuild(notebook_dir: Path, dbp: Path,
         raise
 
 
+def _schema_newer_than_index(notebook_dir: Path, dbp: Path) -> bool:
+    schema_file = notebook_dir / "schema.yaml"
+    return schema_file.exists() and schema_file.stat().st_mtime >= dbp.stat().st_mtime
+
+
+class _IngestFenceTripped(Exception):
+    """Raised when a JSONL file's size dropped below its recorded ingest offset."""
+
+
+def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
+                       schema: dict, sql: SchemaSQL) -> int:
+    """Per-file byte-offset incremental ingest. Returns count of newly-inserted entries.
+
+    Raises _IngestFenceTripped if any JSONL file is smaller than its recorded
+    offset (truncation / external rewrite); caller should fall back to full rebuild.
+    """
+    edir = entries_dir(notebook_dir)
+    if not edir.exists():
+        return 0
+    # Defensive: an existing pre-_ingest_state index opened by new code reaches
+    # this path; create the table so absent rows = offset 0 works transparently.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _ingest_state "
+        "(file TEXT PRIMARY KEY, offset INTEGER NOT NULL)"
+    )
+    total = 0
+    for jsonl_file in sorted(edir.glob("*.jsonl")):
+        size = jsonl_file.stat().st_size
+        row = conn.execute(
+            "SELECT offset FROM _ingest_state WHERE file = ?",
+            (jsonl_file.name,),
+        ).fetchone()
+        offset = row[0] if row else 0
+        if size < offset:
+            raise _IngestFenceTripped(jsonl_file.name)
+        if size == offset:
+            continue
+        with open(jsonl_file, "rb") as f:
+            f.seek(offset)
+            chunk = f.read(size - offset)
+        last_safe_pos = offset
+        cursor = 0
+        try:
+            while True:
+                nl = chunk.find(b"\n", cursor)
+                if nl < 0:
+                    break  # partial trailing line — leave for next read
+                line_bytes = chunk[cursor:nl]
+                cursor = nl + 1
+                line_end_pos = offset + cursor  # byte position AFTER the \n
+                stripped = line_bytes.strip()
+                if not stripped:
+                    last_safe_pos = line_end_pos
+                    continue
+                try:
+                    entry = json.loads(stripped)
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: {jsonl_file.name}: skipping malformed line: {e}",
+                        file=sys.stderr,
+                    )
+                    last_safe_pos = line_end_pos
+                    continue
+                flat = flatten_entry(entry, schema)
+                upsert_entry(conn, flat, sql, commit=False)
+                total += 1
+                last_safe_pos = line_end_pos
+            conn.execute(
+                "INSERT OR REPLACE INTO _ingest_state (file, offset) VALUES (?, ?)",
+                (jsonl_file.name, last_safe_pos),
+            )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+    return total
+
+
 def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.Connection, dict, SchemaSQL]:
     if schema is None:
         schema = load_schema(notebook_dir)
     sql = build_sql(schema)
     dbp = index_path(notebook_dir)
-    if not dbp.exists() or _index_is_stale(notebook_dir, dbp):
+    if not dbp.exists() or _schema_newer_than_index(notebook_dir, dbp):
         count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
         print(f"Index rebuilt: {count} entries", file=sys.stderr)
+    else:
+        conn = sqlite3.connect(str(dbp))
+        try:
+            new_count = incremental_ingest(conn, notebook_dir, schema, sql)
+        except _IngestFenceTripped as e:
+            conn.close()
+            print(f"Ingest fence tripped on {e}; falling back to full rebuild",
+                  file=sys.stderr)
+            count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
+            print(f"Index rebuilt: {count} entries", file=sys.stderr)
+        else:
+            conn.close()
+            if new_count:
+                print(f"Index updated: +{new_count} entries", file=sys.stderr)
     conn = sqlite3.connect(str(dbp))
     return conn, schema, sql
 
 
 def rebuild_from_jsonl(conn: sqlite3.Connection, notebook_dir: Path,
                        schema: dict, sql: SchemaSQL) -> int:
+    """Clear the index and re-ingest every JSONL from byte 0.
+
+    Implemented by clearing entries/entries_fts/_ingest_state and delegating
+    to incremental_ingest. That gets EOF-safe offset bookkeeping for free,
+    so a fresh index ends with _ingest_state populated to current file sizes.
+    """
     edir = entries_dir(notebook_dir)
     if not edir.exists():
         return 0
     conn.execute("DELETE FROM entries")
     conn.execute("DELETE FROM entries_fts")
-    count = 0
-    for jsonl_file in sorted(edir.glob("*.jsonl")):
-        with open(jsonl_file) as f:
-            for lineno, line in enumerate(f, 1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError as e:
-                    print(f"Warning: {jsonl_file.name}:{lineno}: skipping malformed line: {e}",
-                          file=sys.stderr)
-                    continue
-                flat = flatten_entry(entry, schema)
-                upsert_entry(conn, flat, sql, commit=False)
-                count += 1
+    conn.execute("DELETE FROM _ingest_state")
     conn.commit()
-    return count
+    return incremental_ingest(conn, notebook_dir, schema, sql)
 
 
 def print_table(cursor: sqlite3.Cursor) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@ import pytest
 from lab_notebook.cli import (
     LNB_ENV_FILE,
     _find_lnb_env,
-    _index_is_stale,
     _parse_lnb_env,
     cmd_contexts,
     cmd_emit,
@@ -566,37 +565,6 @@ class TestRebuild:
 
 
 # ---------------------------------------------------------------------------
-# staleness detection
-# ---------------------------------------------------------------------------
-
-
-class TestStaleness:
-    def test_stale_after_new_entry(self, notebook):
-        ensure_db(notebook)
-        cmd_emit(make_emit_args(content="New entry"))
-        assert _index_is_stale(notebook, index_path(notebook))
-
-    def test_fresh_after_rebuild(self, notebook):
-        cmd_emit(make_emit_args(content="An entry"))
-        ensure_db(notebook)
-        # Rebuild just happened — touch the index to ensure it's strictly newer
-        import time
-        time.sleep(0.05)
-        idx = index_path(notebook)
-        idx.touch()
-        assert not _index_is_stale(notebook, idx)
-
-    def test_stale_after_schema_change(self, notebook):
-        ensure_db(notebook)
-        import time
-        time.sleep(0.05)
-        (notebook / "schema.yaml").write_text(
-            (notebook / "schema.yaml").read_text() + "\n# modified\n"
-        )
-        assert _index_is_stale(notebook, index_path(notebook))
-
-
-# ---------------------------------------------------------------------------
 # incremental ingest
 # ---------------------------------------------------------------------------
 
@@ -713,9 +681,8 @@ class TestIncrementalIngest:
         conn.execute("DROP TABLE _ingest_state")
         conn.commit()
         conn.close()
-        # Touch the JSONL so the schema fence is not the trigger here — but the
-        # incremental path also handles size-vs-zero-offset transparently. Still,
-        # we want to verify no crash and idempotent re-ingest.
+        # Re-open: incremental_ingest recreates the table and re-ingests via
+        # idempotent INSERT OR REPLACE.
         conn, _, _ = ensure_db(notebook)
         rows = conn.execute("SELECT content FROM entries ORDER BY ts").fetchall()
         conn.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -597,6 +597,180 @@ class TestStaleness:
 
 
 # ---------------------------------------------------------------------------
+# incremental ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalIngest:
+    def _writer_file(self, notebook):
+        return entries_dir(notebook) / "test-writer.jsonl"
+
+    def _read_offset(self, notebook, filename):
+        conn = sqlite3.connect(str(index_path(notebook)))
+        try:
+            row = conn.execute(
+                "SELECT offset FROM _ingest_state WHERE file = ?", (filename,)
+            ).fetchone()
+        finally:
+            conn.close()
+        return row[0] if row else None
+
+    def test_first_read_records_offset(self, notebook):
+        cmd_emit(make_emit_args(content="first entry"))
+        conn, _, _ = ensure_db(notebook)
+        rows = conn.execute("SELECT content FROM entries").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == ["first entry"]
+        wf = self._writer_file(notebook)
+        assert self._read_offset(notebook, wf.name) == wf.stat().st_size
+
+    def test_incremental_fast_path(self, notebook, capsys):
+        for i in range(3):
+            cmd_emit(make_emit_args(content=f"entry {i}"))
+        ensure_db(notebook)[0].close()
+        wf = self._writer_file(notebook)
+        size_after_3 = wf.stat().st_size
+        assert self._read_offset(notebook, wf.name) == size_after_3
+
+        cmd_emit(make_emit_args(content="entry 3"))
+        capsys.readouterr()  # drain prior output
+        conn, _, _ = ensure_db(notebook)
+        err = capsys.readouterr().err
+        rows = conn.execute("SELECT content FROM entries ORDER BY ts").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == [f"entry {i}" for i in range(4)]
+        assert "Index updated: +1 entries" in err
+        assert "Index rebuilt" not in err
+        assert self._read_offset(notebook, wf.name) == wf.stat().st_size
+
+    def test_partial_line_at_eof_is_not_skipped(self, notebook):
+        cmd_emit(make_emit_args(content="complete entry"))
+        ensure_db(notebook)[0].close()
+        wf = self._writer_file(notebook)
+        offset_after_complete = self._read_offset(notebook, wf.name)
+        assert offset_after_complete == wf.stat().st_size
+
+        # Append a partial line (no trailing \n).
+        partial = '{"id":"x-partial","ts":"2026'
+        with open(wf, "a") as f:
+            f.write(partial)
+        conn, _, _ = ensure_db(notebook)
+        rows = conn.execute("SELECT id FROM entries").fetchall()
+        conn.close()
+        assert all(r[0] != "x-partial" for r in rows)
+        assert self._read_offset(notebook, wf.name) == offset_after_complete
+
+        # Complete the line; next read picks it up.
+        rest = '-01-01T00:00:00","writer_id":"test-writer","context":"c","type":"observation","content":"finished","extra":null}\n'
+        with open(wf, "a") as f:
+            f.write(rest)
+        conn, _, _ = ensure_db(notebook)
+        rows = conn.execute("SELECT id, content FROM entries WHERE id = 'x-partial'").fetchall()
+        conn.close()
+        assert rows == [("x-partial", "finished")]
+        assert self._read_offset(notebook, wf.name) == wf.stat().st_size
+
+    def test_truncation_falls_back_to_full_rebuild(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="line A"))
+        cmd_emit(make_emit_args(content="line B"))
+        ensure_db(notebook)[0].close()
+        wf = self._writer_file(notebook)
+        # Truncate so size < recorded offset.
+        with open(wf, "r+") as f:
+            full = f.read()
+            first_line = full.split("\n", 1)[0] + "\n"
+            f.seek(0)
+            f.truncate()
+            f.write(first_line)
+        capsys.readouterr()
+        conn, _, _ = ensure_db(notebook)
+        err = capsys.readouterr().err
+        rows = conn.execute("SELECT content FROM entries").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == ["line A"]
+        assert "fence tripped" in err
+        assert "Index rebuilt" in err
+
+    def test_schema_change_falls_back_to_full_rebuild(self, notebook, capsys):
+        import time
+        cmd_emit(make_emit_args(content="before schema change"))
+        ensure_db(notebook)[0].close()
+        time.sleep(0.05)
+        sf = notebook / "schema.yaml"
+        sf.write_text(sf.read_text() + "\n# touched\n")
+        capsys.readouterr()
+        ensure_db(notebook)[0].close()
+        err = capsys.readouterr().err
+        assert "Index rebuilt" in err
+        assert "Index updated" not in err
+
+    def test_pre_ingest_state_index_migrates_transparently(self, notebook):
+        cmd_emit(make_emit_args(content="entry one"))
+        cmd_emit(make_emit_args(content="entry two"))
+        ensure_db(notebook)[0].close()
+        # Simulate an existing pre-_ingest_state index by dropping the table.
+        conn = sqlite3.connect(str(index_path(notebook)))
+        conn.execute("DROP TABLE _ingest_state")
+        conn.commit()
+        conn.close()
+        # Touch the JSONL so the schema fence is not the trigger here — but the
+        # incremental path also handles size-vs-zero-offset transparently. Still,
+        # we want to verify no crash and idempotent re-ingest.
+        conn, _, _ = ensure_db(notebook)
+        rows = conn.execute("SELECT content FROM entries ORDER BY ts").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == ["entry one", "entry two"]
+        wf = self._writer_file(notebook)
+        assert self._read_offset(notebook, wf.name) == wf.stat().st_size
+
+    def test_malformed_line_in_middle_advances_past_it(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="good before bad"))
+        ensure_db(notebook)[0].close()
+        wf = self._writer_file(notebook)
+        # Append a bad line then a good line.
+        with open(wf, "a") as f:
+            f.write("{not valid json\n")
+            f.write(json.dumps({
+                "id": "good-after-bad",
+                "ts": "2026-01-01T00:00:00",
+                "writer_id": "test-writer",
+                "context": "c",
+                "type": "observation",
+                "content": "good after bad",
+                "extra": None,
+            }) + "\n")
+        capsys.readouterr()
+        conn, _, _ = ensure_db(notebook)
+        err = capsys.readouterr().err
+        rows = conn.execute("SELECT id, content FROM entries ORDER BY ts").fetchall()
+        conn.close()
+        ids = [r[0] for r in rows]
+        assert "good-after-bad" in ids
+        assert "skipping malformed line" in err
+        assert self._read_offset(notebook, wf.name) == wf.stat().st_size
+
+    def test_only_changed_writer_offset_advances(self, notebook, monkeypatch):
+        cmd_emit(make_emit_args(content="from A"))
+        monkeypatch.setenv("LAB_NOTEBOOK_WRITER", "writer-b")
+        cmd_emit(make_emit_args(content="from B"))
+        ensure_db(notebook)[0].close()
+
+        edir = entries_dir(notebook)
+        a_file = edir / "test-writer.jsonl"
+        b_file = edir / "writer-b.jsonl"
+        a_offset_before = self._read_offset(notebook, a_file.name)
+        b_offset_before = self._read_offset(notebook, b_file.name)
+
+        # Only writer-b appends.
+        cmd_emit(make_emit_args(content="from B again"))
+        ensure_db(notebook)[0].close()
+
+        assert self._read_offset(notebook, a_file.name) == a_offset_before
+        assert self._read_offset(notebook, b_file.name) > b_offset_before
+        assert self._read_offset(notebook, b_file.name) == b_file.stat().st_size
+
+
+# ---------------------------------------------------------------------------
 # multiple writers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Incremental rebuild — implementation handoff

## Goal

Replace today's "full DELETE + re-parse every JSONL on every stale read" with per-file byte-offset incremental ingest. Full rebuild stays as the always-correct fallback whenever an invariant is broken. Why this framing: O(N) re-parse on every read is the only architectural cost in the current "JSONL is truth, SQLite is disposable" design (cli.py:343-367); the ceiling moves from "tens of thousands of entries" to "as much as you want" with a small, contained change.

## Current state

Design is settled and illustrated at `handoff/incremental-rebuild.html` (open in a browser; side-by-side before/after, fences, EOF safety rule). No code changes yet. The change is additive — existing `_atomic_rebuild` / `rebuild_from_jsonl` / `_index_is_stale` are preserved as the fallback path. The work is: (1) add the `_ingest_state` table DDL, (2) write a new `incremental_ingest` function alongside `rebuild_from_jsonl`, (3) branch in `ensure_db`, (4) tests.

## Decisions (with why)

- **Add `_ingest_state(file TEXT PRIMARY KEY, offset INTEGER NOT NULL)` to `index.sqlite`.** Append its `CREATE TABLE IF NOT EXISTS` to the existing `build_sql.create_sql` string (cli.py:146-156). State lives with the index; one artifact = impossible to drift; `_atomic_rebuild`'s tempfile-and-rename naturally clears it on full rebuild.

- **Reuse the existing `upsert_entry` (cli.py:283-297) from the new incremental path; do not write a parallel insert.** It already handles re-insert idempotently: `INSERT OR REPLACE` on `entries`, plus `DELETE FROM entries_fts WHERE rowid = ?` then `INSERT` for FTS5. So FTS5 dedupe is already solved by the existing pattern — no `INSERT OR IGNORE`, no rowid juggling needed in new code.

- **Per-file transaction shape: `BEGIN; upsert each new line; UPDATE _ingest_state SET offset = last_safe_pos; COMMIT;`.** Offset only advances on successful commit. Rollback leaves a clean prior state; next read retries from the prior offset. Idempotent retries are safe via the previous decision.

- **Advance offset only to the byte position after the last successfully-parsed, `\n`-terminated line in the new region.** A partial trailing line — from a crashed emit or an in-flight write during read — must NOT be skipped past. Leaving the offset before it means the next read retries that region; the writer's eventual completion is then ingested. This is the only correctness landmine in the design.

- **No special-case migration branch for existing `index.sqlite` files.** On first run with the new code, `executescript(sql.create)` creates `_ingest_state` empty. Absent rows = offset 0. The incremental path naturally reads each JSONL from byte 0 the first time (equivalent work to one full re-ingest), then incremental thereafter. No version detection, no migration code.

- **`cmd_rebuild` is unchanged (cli.py:628-634).** It calls `_atomic_rebuild`, which writes a fresh `index.sqlite` via tempfile + atomic rename. The fresh index has an empty `_ingest_state` because the modified `create_sql` includes the new DDL. Manual escape hatch stays as-is.

- **No new user-facing flag** (no `--incremental`, no `--no-incremental`). The system is always correct; incremental is just sometimes faster. A flag means documenting and supporting it forever for an optimization users shouldn't think about.

- **Schema change → full rebuild, not incremental ALTER.** ALTER + FTS5 virtual-table surgery is a tar pit for marginal gain. The existing `schema.yaml` mtime ≥ index mtime check in `_index_is_stale` (cli.py:300-311) is the trigger; route it into `_atomic_rebuild` as today.

- **Strict scope: do NOT modify `cmd_search` (cli.py:595-617).** A two-stage `bm25()`→`ORDER BY ts DESC` rerank is a separate, parked change. Bundling it would obscure the diff and complicate review.

## Ruled out (with why)

- **Sidecar JSON file for offsets** (e.g. `.lnb/_ingest_state.json`). Two artifacts that must stay in sync; either can be deleted independently and drift. SQLite table is atomic with the index it describes.

- **Line numbers instead of byte offsets.** Counting lines requires reading from byte 0 every time. Defeats the entire optimization.

- **`mtime` column in `_ingest_state`.** Redundant with the `size < offset` fence — adds a column and offers nothing extra.

- **Per-`emit` SQLite write** (emit also inserts into the index live, alongside the JSONL append). Violates "JSONL is truth, SQLite is disposable" — adds write-side coordination across multiple processes; deviates from the convergent agent-memory pattern documented in `handoff/jsonl-memory-research.md`.

## Load-bearing assumptions

- **JSONL files are append-only in normal use.** Hand-edits, truncation, external rewrites are exceptional and trip the `size < offset` fence into full rebuild. Don't try to reconcile non-append edits.

- **`entries.id` is globally unique** across the notebook (generated as `YYYYMMDDTHHMMSS-<4-hex>` by `generate_id`). The existing `INSERT OR REPLACE` pattern's correctness depends on this.

- **Single writer per JSONL file** (per-writer file model — see cli.py:573, `f"{writer_id}.jsonl"`). Different writers go to different files. No inter-file race exists or needs to be invented.

- **Concurrent readers may both run incremental ingest on the same index.** SQLite serializes via its own locking; do not add file locks or OS-level mutexes. Worst case: same lines `INSERT OR REPLACE`d twice. Wasteful but correct.

- **The schema-change fence uses `schema.yaml` mtime ≥ index mtime** as today (cli.py:300-311). Continue using it; do not invent a new check.

- **This is an addition alongside existing functions, not a rewrite.** `_atomic_rebuild`, `rebuild_from_jsonl`, `_index_is_stale` stay as the fallback. The new function is a separate `incremental_ingest` (or similarly named) called from `ensure_db` when the schema fence passes.

## Open threads

- **Orphan `_ingest_state` rows** (a JSONL file was deleted from disk but its row remains). Harmless — never matches a live file — but a one-line cleanup (`DELETE FROM _ingest_state WHERE file NOT IN (...)`) could run at the start of incremental ingest. Not blocking; intern judgment call.

- **Whether `format_schema_help()` (cli.py:58-80) should mention `_ingest_state`.** Probably no — it's internal — but worth a moment of thought during implementation. Easy to revisit if a user complaint surfaces.

- **Two-stage `search` rerank** (BM25 candidates → `ORDER BY ts DESC` via a CTE around `bm25(entries_fts)`). Adjacent to this work in the codebase, confirmed as the right shape, parked as a separate change. Out of scope here; OK to flag for follow-up in the PR description.

- **Minimal `parent_id` / graph-shape addition** (a single optional schema field for causal entry chains). Discussed earlier, parked. Out of scope.

## Pointers

- **`handoff/incremental-rebuild.html`** — primary visual reference. Side-by-side before/after, fences, EOF safety. Read first.
- **`handoff/jsonl-memory-research.md`** — motivates "JSONL is truth, SQLite is disposable." Read for context on *why* the rebuild is read-triggered, not write-triggered.
- **`src/lab_notebook/cli.py:125-178`** (`build_sql`) — where the new `_ingest_state` `CREATE TABLE IF NOT EXISTS` gets appended to `create_sql`. The `executescript` consumer at `_atomic_rebuild` (cli.py:321) handles multi-statement strings already.
- **`src/lab_notebook/cli.py:283-297`** (`upsert_entry`) — existing idempotent row insert + FTS5 re-insert. Call this from the new incremental path with `commit=False`; do one commit per file together with the offset update.
- **`src/lab_notebook/cli.py:300-340`** (`_index_is_stale`, `_atomic_rebuild`, `ensure_db`) — the integration point. The new branching lives in `ensure_db`: if the index exists and the schema fence passes, call the new incremental function; otherwise fall back to `_atomic_rebuild` exactly as today.
- **`src/lab_notebook/cli.py:343-367`** (`rebuild_from_jsonl`) — the existing loop the new `incremental_ingest` mirrors (per-file `for line in f:` + `upsert_entry`), but with `seek(off)` and offset bookkeeping.
- **`src/lab_notebook/cli.py:524-579`** (`cmd_emit`) — confirms the emit invariant: JSONL append + `fsync` only, no SQLite write. The new ingest must not require any change to emit.
- **`tests/test_cli.py`** — existing test patterns; new tests belong here. Coverage to aim for: fresh notebook → first read; emit-then-read incremental fast path; partial-line-at-EOF (don't advance past it; complete the line; next read picks it up); JSONL truncated → full rebuild fallback; `schema.yaml` newer than index → full rebuild fallback; existing pre-`_ingest_state` index opened by new code → re-ingests from offset 0 with no special-case code.
