### PR TITLE
feat: retract entries via append-only tombstones

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ file on disk (mutually exclusive with `--template`).
 Write a notebook entry. Required: `--context`, `--type`, content.
 Custom field flags (e.g. `--repo`, `--tags`) are generated from `schema.yaml`.
 
+### `retract ID --reason "why"`
+
+Forget an entry that is wrong or out of date. Both `ID` and `--reason` are
+required. Retract appends a tombstone record to the notebook — it does **not**
+edit or remove the original line. On the next indexed read the target row is
+deleted from `index.sqlite` (and from full-text search); the tombstone itself
+is never returned as an entry.
+
+Because the index is rebuilt from the JSONL, the deletion survives `rebuild`.
+The retraction is logical, not physical: the original entry and the tombstone
+(with its reason) both remain in `entries/*.jsonl` as the audit trail of what
+was forgotten and why. To recover a retracted entry, restore it from a JSONL
+backup and `rebuild` — there is no un-retract command. Any writer may retract
+any entry by id.
+
 ### `sql "query"`
 
 Run raw SQL against the index. Auto-rebuilds if `index.sqlite` is missing.
@@ -184,5 +199,21 @@ Each writer gets their own JSONL file. No merge conflicts.
   "tags": ["mae", "masking"],
   "artifacts": ["research-lrn091:results/S01.csv"],
   "content": "MAE with 75% masking spends most capacity on background."
+}
+```
+
+A `retract` appends a tombstone record instead of an entry. Its `type` is
+`_retract`, `retracts` is the id being forgotten, and `reason` is why. It is a
+control record — it deletes its target from the index and is never indexed as
+an entry itself:
+
+```json
+{
+  "id": "20260322T091500-c3d1",
+  "ts": "2026-03-22T09:15:00",
+  "writer_id": "cong",
+  "type": "_retract",
+  "retracts": "20260321T143022-a7f2",
+  "reason": "superseded by a corrected measurement"
 }
 ```

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -97,6 +97,10 @@ def load_schema(notebook_dir: Path) -> dict:
     if not isinstance(schema.get("types"), list) or not schema["types"]:
         print("Error: schema.yaml must have a non-empty 'types' list.", file=sys.stderr)
         sys.exit(1)
+    if RETRACT_TYPE in schema["types"]:
+        print(f"Error: '{RETRACT_TYPE}' is a reserved control-record type and "
+              f"cannot be declared in schema.yaml.", file=sys.stderr)
+        sys.exit(1)
     fields = schema.get("fields") or {}
     schema["fields"] = fields
     reserved = set(CORE_FIELDS) | {"extra"}
@@ -301,15 +305,18 @@ def upsert_entry(conn: sqlite3.Connection, entry: dict, sql: SchemaSQL,
         conn.commit()
 
 
-def delete_entry(conn: sqlite3.Connection, target_id: str) -> None:
+def delete_entry(conn: sqlite3.Connection, target_id: str) -> bool:
     """Hard-delete a target entry and its FTS row. No-op if it isn't present
-    (already retracted, or the tombstone references an id that never existed)."""
+    (already retracted, or the tombstone references an id that never existed).
+    Returns True if a row was actually removed, False on the no-op path."""
     row = conn.execute(
         "SELECT rowid FROM entries WHERE id = ?", (target_id,)
     ).fetchone()
     if row:
         conn.execute("DELETE FROM entries_fts WHERE rowid = ?", (row[0],))
         conn.execute("DELETE FROM entries WHERE id = ?", (target_id,))
+        return True
+    return False
 
 
 def _atomic_rebuild(notebook_dir: Path, dbp: Path,
@@ -342,8 +349,10 @@ class _IngestFenceTripped(Exception):
 
 
 def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
-                       schema: dict, sql: SchemaSQL) -> int:
-    """Per-file byte-offset incremental ingest. Returns count of newly-inserted entries.
+                       schema: dict, sql: SchemaSQL) -> tuple[int, int]:
+    """Per-file byte-offset incremental ingest. Returns (added, retracted): the
+    count of newly-inserted entries and the count of entries actually removed by
+    tombstones in this pass.
 
     Raises _IngestFenceTripped if any JSONL file is smaller than its recorded
     offset (truncation / external rewrite); caller should fall back to full rebuild.
@@ -415,8 +424,13 @@ def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
                 total += 1
                 last_safe_pos = line_end_pos
             new_offsets[jsonl_file.name] = last_safe_pos
+        # Deferred-offset safety relies on cmd_retract validating that the target
+        # is already indexed before it writes the tombstone, so a tombstone can
+        # never outrun its target into a later-sorted file and resurrect it.
+        retracted = 0
         for target in pending_deletes:
-            delete_entry(conn, target)
+            if delete_entry(conn, target):
+                retracted += 1
         for name, pos in new_offsets.items():
             conn.execute(
                 "INSERT OR REPLACE INTO _ingest_state (file, offset) VALUES (?, ?)",
@@ -426,7 +440,7 @@ def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
     except BaseException:
         conn.rollback()
         raise
-    return total
+    return total, retracted
 
 
 def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.Connection, dict, SchemaSQL]:
@@ -440,9 +454,9 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
     else:
         conn = sqlite3.connect(str(dbp))
         fence_tripped = None
-        new_count = 0
+        added = retracted = 0
         try:
-            new_count = incremental_ingest(conn, notebook_dir, schema, sql)
+            added, retracted = incremental_ingest(conn, notebook_dir, schema, sql)
         except _IngestFenceTripped as e:
             fence_tripped = str(e)
         finally:
@@ -452,14 +466,19 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
                   f"falling back to full rebuild", file=sys.stderr)
             count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
             print(f"Index rebuilt: {count} entries", file=sys.stderr)
-        elif new_count:
-            print(f"Index updated: +{new_count} entries", file=sys.stderr)
+        elif added and retracted:
+            print(f"Index updated: +{added} entries, -{retracted} retracted",
+                  file=sys.stderr)
+        elif added:
+            print(f"Index updated: +{added} entries", file=sys.stderr)
+        elif retracted:
+            print(f"Index updated: -{retracted} retracted", file=sys.stderr)
     conn = sqlite3.connect(str(dbp))
     return conn, schema, sql
 
 
 def rebuild_from_jsonl(conn: sqlite3.Connection, notebook_dir: Path,
-                       schema: dict, sql: SchemaSQL) -> int:
+                       schema: dict, sql: SchemaSQL) -> tuple[int, int]:
     """Clear the index and re-ingest every JSONL from byte 0.
 
     Implemented by clearing entries/entries_fts/_ingest_state and delegating
@@ -468,7 +487,7 @@ def rebuild_from_jsonl(conn: sqlite3.Connection, notebook_dir: Path,
     """
     edir = entries_dir(notebook_dir)
     if not edir.exists():
-        return 0
+        return 0, 0
     conn.execute("DELETE FROM entries")
     conn.execute("DELETE FROM entries_fts")
     conn.execute("DELETE FROM _ingest_state")

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -359,7 +359,7 @@ def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
     """
     edir = entries_dir(notebook_dir)
     if not edir.exists():
-        return 0
+        return 0, 0
     # Defensive: an existing pre-_ingest_state index opened by new code reaches
     # this path; create the table so absent rows = offset 0 works transparently.
     conn.execute(

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -3,6 +3,7 @@
 Usage:
     lab-notebook init [path] [--template NAME]
     lab-notebook emit --context X --type Y "content"
+    lab-notebook retract ID --reason "why"
     lab-notebook sql "SELECT ..."
     lab-notebook search "query"
     lab-notebook schema
@@ -28,6 +29,7 @@ from pathlib import Path
 import yaml
 
 CORE_FIELDS = ("id", "ts", "writer_id", "context", "type", "content")
+RETRACT_TYPE = "_retract"  # control-record type: tombstones a target entry, never stored as a row
 BUILTIN_FIELDS = {"artifacts": {"type": "list"}}  # always present, nullable; merged into every schema
 VALID_FIELD_TYPES = ("text", "integer", "real", "list")
 TYPE_MAP = {"text": "TEXT", "integer": "INTEGER", "real": "REAL", "list": "TEXT"}
@@ -299,6 +301,17 @@ def upsert_entry(conn: sqlite3.Connection, entry: dict, sql: SchemaSQL,
         conn.commit()
 
 
+def delete_entry(conn: sqlite3.Connection, target_id: str) -> None:
+    """Hard-delete a target entry and its FTS row. No-op if it isn't present
+    (already retracted, or the tombstone references an id that never existed)."""
+    row = conn.execute(
+        "SELECT rowid FROM entries WHERE id = ?", (target_id,)
+    ).fetchone()
+    if row:
+        conn.execute("DELETE FROM entries_fts WHERE rowid = ?", (row[0],))
+        conn.execute("DELETE FROM entries WHERE id = ?", (target_id,))
+
+
 def _atomic_rebuild(notebook_dir: Path, dbp: Path,
                      schema: dict, sql: SchemaSQL) -> int:
     """Rebuild the index into a temp file, then atomically rename into place."""
@@ -307,7 +320,10 @@ def _atomic_rebuild(notebook_dir: Path, dbp: Path,
     try:
         conn = sqlite3.connect(tmp)
         conn.executescript(sql.create)
-        count = rebuild_from_jsonl(conn, notebook_dir, schema, sql)
+        rebuild_from_jsonl(conn, notebook_dir, schema, sql)
+        # Report the net active count (rows actually in the index after
+        # tombstones are applied), not the number of lines ingested.
+        count = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
         conn.close()
         os.rename(tmp, str(dbp))
         return count
@@ -341,24 +357,33 @@ def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
         "CREATE TABLE IF NOT EXISTS _ingest_state "
         "(file TEXT PRIMARY KEY, offset INTEGER NOT NULL)"
     )
+    # Two-phase, single-transaction: scan every file first (upserting content
+    # entries and collecting tombstone targets + new offsets), then apply all
+    # deletes and offset writes in one commit. Deferring deletes makes retraction
+    # order-independent — a tombstone may target an entry in a later-sorted file
+    # (any writer can retract any id), and on a full rebuild the target is only
+    # inserted later in the same pass. Committing once keeps the tombstone's
+    # offset advance atomic with its delete, so a crash can't strand a target.
     total = 0
-    for jsonl_file in sorted(edir.glob("*.jsonl")):
-        size = jsonl_file.stat().st_size
-        row = conn.execute(
-            "SELECT offset FROM _ingest_state WHERE file = ?",
-            (jsonl_file.name,),
-        ).fetchone()
-        offset = row[0] if row else 0
-        if size < offset:
-            raise _IngestFenceTripped(jsonl_file.name)
-        if size == offset:
-            continue
-        with open(jsonl_file, "rb") as f:
-            f.seek(offset)
-            chunk = f.read(size - offset)
-        last_safe_pos = offset
-        cursor = 0
-        try:
+    new_offsets: dict[str, int] = {}
+    pending_deletes: list[str] = []
+    try:
+        for jsonl_file in sorted(edir.glob("*.jsonl")):
+            size = jsonl_file.stat().st_size
+            row = conn.execute(
+                "SELECT offset FROM _ingest_state WHERE file = ?",
+                (jsonl_file.name,),
+            ).fetchone()
+            offset = row[0] if row else 0
+            if size < offset:
+                raise _IngestFenceTripped(jsonl_file.name)
+            if size == offset:
+                continue
+            with open(jsonl_file, "rb") as f:
+                f.seek(offset)
+                chunk = f.read(size - offset)
+            last_safe_pos = offset
+            cursor = 0
             while True:
                 nl = chunk.find(b"\n", cursor)
                 if nl < 0:
@@ -379,18 +404,28 @@ def incremental_ingest(conn: sqlite3.Connection, notebook_dir: Path,
                     )
                     last_safe_pos = line_end_pos
                     continue
+                if entry.get("type") == RETRACT_TYPE:
+                    target = entry.get("retracts")
+                    if target:
+                        pending_deletes.append(target)
+                    last_safe_pos = line_end_pos
+                    continue
                 flat = flatten_entry(entry, schema)
                 upsert_entry(conn, flat, sql, commit=False)
                 total += 1
                 last_safe_pos = line_end_pos
+            new_offsets[jsonl_file.name] = last_safe_pos
+        for target in pending_deletes:
+            delete_entry(conn, target)
+        for name, pos in new_offsets.items():
             conn.execute(
                 "INSERT OR REPLACE INTO _ingest_state (file, offset) VALUES (?, ?)",
-                (jsonl_file.name, last_safe_pos),
+                (name, pos),
             )
-            conn.commit()
-        except BaseException:
-            conn.rollback()
-            raise
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
     return total
 
 
@@ -653,6 +688,46 @@ def cmd_emit(args: argparse.Namespace) -> None:
     print(f"[{entry['type']}] {entry['id']}  {entry['context']}")
 
 
+def cmd_retract(args: argparse.Namespace) -> None:
+    notebook_dir = get_notebook_dir()
+    writer_id = get_writer_id()
+
+    # Confirm the target exists in the current index. A missing id means it was
+    # never written or has already been retracted — either way, nothing to do.
+    conn, schema, sql = ensure_db(notebook_dir)
+    try:
+        found = conn.execute(
+            "SELECT id FROM entries WHERE id = ?", (args.id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    if not found:
+        print(f"Error: entry '{args.id}' not found "
+              f"(already retracted or never existed)", file=sys.stderr)
+        sys.exit(1)
+
+    tombstone = {
+        "id": generate_id(),
+        "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        "writer_id": writer_id,
+        "type": RETRACT_TYPE,
+        "retracts": args.id,
+        "reason": args.reason,
+    }
+
+    # Append the tombstone to the retracting writer's own file. The deletion is
+    # applied on the next indexed read, the same way emit indexes lazily.
+    edir = entries_dir(notebook_dir)
+    edir.mkdir(exist_ok=True)
+    writer_file = edir / f"{writer_id}.jsonl"
+    with open(writer_file, "a") as f:
+        f.write(json.dumps(tombstone, ensure_ascii=False) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+
+    print(f"[retracted] {args.id}  ({args.reason})")
+
+
 def cmd_sql(args: argparse.Namespace) -> None:
     notebook_dir = get_notebook_dir()
     conn, schema, sql = ensure_db(notebook_dir)
@@ -801,6 +876,15 @@ def main() -> None:
         pass  # schema loading failed — emit will load schema at runtime
 
     p_emit.set_defaults(func=cmd_emit, _schema=_parsed_schema)
+
+    # -- retract --
+    p_retract = sub.add_parser(
+        "retract",
+        help="Retract an entry by id (appends a tombstone; entry stays in JSONL)")
+    p_retract.add_argument("id", help="Id of the entry to retract")
+    p_retract.add_argument("--reason", required=True,
+                           help="Why this entry is being retracted (recorded in the tombstone)")
+    p_retract.set_defaults(func=cmd_retract)
 
     # -- sql --
     p_sql = sub.add_parser("sql", help="Run a SQL query against the index")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -1276,6 +1277,18 @@ class TestRetract:
         finally:
             conn.close()
         assert offset == wf.stat().st_size
+
+    def test_incremental_ingest_missing_entries_dir(self, notebook):
+        # Index built once, then entries/ disappears (deleted, or
+        # LAB_NOTEBOOK_DIR repointed at a dir with only schema.yaml). The
+        # incremental path must return cleanly, not crash on tuple-unpack.
+        cmd_emit(make_emit_args(content="builds the index"))
+        ensure_db(notebook)[0].close()  # build index so next read is incremental
+
+        shutil.rmtree(entries_dir(notebook))  # entries/ gone; index + schema remain
+
+        conn, _, _ = ensure_db(notebook)  # reaches incremental_ingest, edir missing
+        conn.close()  # must not raise TypeError
 
     def test_rebuild_reports_net_active_count(self, notebook, capsys):
         cmd_emit(make_emit_args(content="keep"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1288,3 +1288,40 @@ class TestRetract:
         out = capsys.readouterr().out
         assert "1 entries" in out
         assert "2 entries" not in out
+
+    def test_reserved_retract_type_rejected(self, notebook, capsys):
+        # A schema may not declare the reserved control-record type; doing so
+        # would let emitted rows be silently swallowed as tombstones.
+        (notebook / "schema.yaml").write_text(
+            "types:\n"
+            "  - observation\n"
+            "  - _retract\n"
+        )
+        with pytest.raises(SystemExit) as exc:
+            load_schema(notebook)
+        assert exc.value.code == 1
+        assert "_retract" in capsys.readouterr().err
+
+    def test_pure_retract_pass_reports_retracted_count(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="to retract"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        ensure_db(notebook)[0].close()  # build index so retract uses incremental path
+        cmd_retract(make_retract_args(target))  # tombstone applied on next read
+        capsys.readouterr()  # clear
+
+        ensure_db(notebook)[0].close()  # incremental pass applies the tombstone
+        assert "Index updated: -1 retracted" in capsys.readouterr().err
+
+    def test_mixed_add_and_retract_pass_reports_both(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="to retract"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        ensure_db(notebook)[0].close()  # build index; offset at EOF
+
+        # Stage both a pending tombstone and a pending add for one incremental
+        # pass: retract appends the tombstone unread, then emit appends content.
+        cmd_retract(make_retract_args(target))
+        cmd_emit(make_emit_args(content="brand new"))
+        capsys.readouterr()  # clear
+
+        ensure_db(notebook)[0].close()  # single pass: +1 add, -1 retract
+        assert "Index updated: +1 entries, -1 retracted" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from lab_notebook.cli import (
     cmd_emit,
     cmd_init,
     cmd_rebuild,
+    cmd_retract,
     cmd_search,
     cmd_schema,
     cmd_sql,
@@ -1141,3 +1142,149 @@ class TestInitDefault:
         lnb_env = tmp_path / LNB_ENV_FILE
         content = lnb_env.read_text()
         assert str(nb_dir) in content
+
+
+# ---------------------------------------------------------------------------
+# retract
+# ---------------------------------------------------------------------------
+
+
+def make_retract_args(target_id, reason="no longer accurate"):
+    return argparse.Namespace(id=target_id, reason=reason)
+
+
+def _entry_count(notebook):
+    conn, _, _ = ensure_db(notebook)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _last_id_in_file(notebook, filename):
+    """Return the id of the last record in a writer's JSONL file."""
+    path = entries_dir(notebook) / filename
+    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    return json.loads(lines[-1])["id"]
+
+
+class TestRetract:
+    def test_removes_target_keeps_others(self, notebook):
+        cmd_emit(make_emit_args(content="keep me"))
+        keep_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_emit(make_emit_args(content="drop me"))
+        drop_id = _last_id_in_file(notebook, "test-writer.jsonl")
+
+        cmd_retract(make_retract_args(drop_id))
+
+        conn, _, _ = ensure_db(notebook)
+        rows = [r[0] for r in conn.execute("SELECT id FROM entries").fetchall()]
+        conn.close()
+        assert keep_id in rows
+        assert drop_id not in rows
+
+    def test_target_gone_from_fts_search(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="unique_token_xyz here"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(target))
+        capsys.readouterr()  # clear
+
+        cmd_search(argparse.Namespace(query="unique_token_xyz", context=None, type=None))
+        out = capsys.readouterr().out
+        assert "unique_token_xyz" not in out
+
+    def test_tombstone_is_not_a_queryable_entry(self, notebook):
+        cmd_emit(make_emit_args(content="solo"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(target))
+
+        conn, _, _ = ensure_db(notebook)
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+            tombstones = conn.execute(
+                "SELECT COUNT(*) FROM entries WHERE type = '_retract'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert total == 0
+        assert tombstones == 0
+
+    def test_tombstone_preserved_in_jsonl(self, notebook):
+        cmd_emit(make_emit_args(content="audit trail"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(target, reason="superseded"))
+
+        lines = [ln for ln in (entries_dir(notebook) / "test-writer.jsonl")
+                 .read_text().splitlines() if ln.strip()]
+        tombstone = json.loads(lines[-1])
+        assert tombstone["type"] == "_retract"
+        assert tombstone["retracts"] == target
+        assert tombstone["reason"] == "superseded"
+
+    def test_reason_is_required(self, notebook, monkeypatch):
+        cmd_emit(make_emit_args(content="needs reason"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        monkeypatch.setattr("sys.argv", ["lab-notebook", "retract", target])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 2
+
+    def test_nonexistent_id_errors(self, notebook, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_retract(make_retract_args("20990101T000000-dead"))
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_already_retracted_errors(self, notebook):
+        cmd_emit(make_emit_args(content="retract twice"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(target))
+        # First retract is applied on the read inside the second retract.
+        with pytest.raises(SystemExit) as exc:
+            cmd_retract(make_retract_args(target))
+        assert exc.value.code == 1
+
+    def test_cross_writer_retract_survives_rebuild(self, notebook, monkeypatch):
+        # 'zoe' authors the entry; 'amy' retracts it. amy.jsonl sorts before
+        # zoe.jsonl, so on a full rebuild the tombstone is read before the
+        # target is inserted — the deferred two-phase delete must still apply.
+        monkeypatch.setenv("LAB_NOTEBOOK_WRITER", "zoe")
+        cmd_emit(make_emit_args(content="zoe's entry"))
+        target = _last_id_in_file(notebook, "zoe.jsonl")
+
+        monkeypatch.setenv("LAB_NOTEBOOK_WRITER", "amy")
+        cmd_retract(make_retract_args(target))
+
+        cmd_rebuild(argparse.Namespace())
+        assert _entry_count(notebook) == 0
+
+    def test_incremental_path_advances_offset(self, notebook):
+        cmd_emit(make_emit_args(content="incremental"))
+        target = _last_id_in_file(notebook, "test-writer.jsonl")
+        # Build the index first so retract exercises the incremental path.
+        ensure_db(notebook)[0].close()
+
+        cmd_retract(make_retract_args(target))
+        assert _entry_count(notebook) == 0
+
+        wf = entries_dir(notebook) / "test-writer.jsonl"
+        conn = sqlite3.connect(str(index_path(notebook)))
+        try:
+            offset = conn.execute(
+                "SELECT offset FROM _ingest_state WHERE file = ?", (wf.name,)
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert offset == wf.stat().st_size
+
+    def test_rebuild_reports_net_active_count(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="keep"))
+        cmd_emit(make_emit_args(content="drop"))
+        drop_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(drop_id))
+        capsys.readouterr()  # clear
+
+        cmd_rebuild(argparse.Namespace())
+        out = capsys.readouterr().out
+        assert "1 entries" in out
+        assert "2 entries" not in out


### PR DESCRIPTION
## What

Adds a `retract ID --reason "why"` command so the notebook can be used as *system memory* — wrong or out-of-date entries can be forgotten — without breaking the append-only model.

```
lab-notebook retract 20260321T143022-a7f2 --reason "superseded by corrected measurement"
```

## How it works

- **Append-only logical delete.** Retract appends a `_retract` tombstone record (`{type, retracts, reason}`) to the retracting writer's JSONL. On the next ingest the target row + its FTS row are hard-deleted from `index.sqlite`. The original entry and the tombstone both stay in the JSONL as the audit trail of what was forgotten and why.
- **Survives rebuild.** Because the index is derived from the JSONL, the deletion is reapplied on every rebuild.
- **Order-independent.** `incremental_ingest` is now a two-phase, single-commit pass: scan all files collecting tombstone targets + offsets, then apply deletes and offset writes in one transaction. This handles the case where a tombstone in one writer's file targets an entry in a later-sorted writer's file (any writer may retract any id), which on a full rebuild is only inserted later in the same pass. The single commit keeps a tombstone's offset advance atomic with its delete, so a crash can't strand a target.

## Design decisions (confirmed during planning)

- **Retract only** — no supersede/amend verb; corrections = retract + emit-new.
- **Hard delete from the index** — no soft status / `--show-retracted`. Recover by restoring from a JSONL backup and rebuilding.
- **Reason required** on every retract.
- **Anyone retracts anything** — no ownership check.

## Also

`_atomic_rebuild` now reports the **net active row count** (`COUNT(*)` after ingest) rather than lines ingested, so `Rebuilt index: N entries` reflects what's actually queryable after tombstones are applied.

## Tests

10 new tests (`TestRetract`): removal from search/FTS, tombstone-not-queryable, tombstone-preserved-in-JSONL, reason-required, nonexistent/already-retracted errors, cross-writer-survives-rebuild (the ordering guarantee), incremental-path offset advance, and net-count reporting. Full suite: 105 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)