### PR TITLE
feat: US-002 - Replace sys.exit error handling with LnbError caught in main()

### DIFF
--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -27,6 +27,7 @@ from .schema import (
     CORE_FIELDS,
     DEFAULT_TEMPLATE,
     RETRACT_TYPE,
+    LnbError,
     build_sql,
     format_schema_help,
     load_schema,
@@ -443,7 +444,11 @@ def main() -> None:
     p_template.set_defaults(func=cmd_template)
 
     args = parser.parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except LnbError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/lab_notebook/schema.py
+++ b/src/lab_notebook/schema.py
@@ -5,12 +5,16 @@ depend on it, never the other way around.
 """
 from __future__ import annotations
 
-import sys
 from collections import namedtuple
 from importlib.resources import files
 from pathlib import Path
 
 import yaml
+
+
+class LnbError(Exception):
+    """User-facing error. main() prints str(e) to stderr and exits 1."""
+
 
 CORE_FIELDS = ("id", "ts", "writer_id", "context", "type", "content")
 RETRACT_TYPE = "_retract"  # control-record type: tombstones a target entry, never stored as a row
@@ -53,38 +57,29 @@ def format_schema_help(schema: dict) -> str:
 def load_schema(notebook_dir: Path) -> dict:
     schema_file = notebook_dir / "schema.yaml"
     if not schema_file.exists():
-        print(f"Error: {schema_file} not found. Run 'lab-notebook init' first.",
-              file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Error: {schema_file} not found. Run 'lab-notebook init' first.")
     with open(schema_file) as f:
         schema = yaml.safe_load(f)
     if not isinstance(schema.get("types"), list) or not schema["types"]:
-        print("Error: schema.yaml must have a non-empty 'types' list.", file=sys.stderr)
-        sys.exit(1)
+        raise LnbError("Error: schema.yaml must have a non-empty 'types' list.")
     if RETRACT_TYPE in schema["types"]:
-        print(f"Error: '{RETRACT_TYPE}' is a reserved control-record type and "
-              f"cannot be declared in schema.yaml.", file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Error: '{RETRACT_TYPE}' is a reserved control-record type and "
+                       f"cannot be declared in schema.yaml.")
     fields = schema.get("fields") or {}
     schema["fields"] = fields
     reserved = set(CORE_FIELDS) | {"extra"}
     for name, spec in fields.items():
         if name in reserved:
-            print(f"Error: field '{name}' conflicts with a core field.", file=sys.stderr)
-            sys.exit(1)
+            raise LnbError(f"Error: field '{name}' conflicts with a core field.")
         if not isinstance(spec, dict):
-            print(f"Error: field '{name}' must be a mapping (e.g. {{type: text}}), "
-                  f"got '{spec}'.", file=sys.stderr)
-            sys.exit(1)
+            raise LnbError(f"Error: field '{name}' must be a mapping (e.g. {{type: text}}), "
+                           f"got '{spec}'.")
         if name in BUILTIN_FIELDS:
-            print(f"Error: field '{name}' is built-in and cannot be redeclared in schema.",
-                  file=sys.stderr)
-            sys.exit(1)
+            raise LnbError(f"Error: field '{name}' is built-in and cannot be redeclared in schema.")
         ftype = spec.get("type")
         if ftype not in VALID_FIELD_TYPES:
-            print(f"Error: field '{name}' has invalid type '{ftype}'. "
-                  f"Must be one of {VALID_FIELD_TYPES}.", file=sys.stderr)
-            sys.exit(1)
+            raise LnbError(f"Error: field '{name}' has invalid type '{ftype}'. "
+                           f"Must be one of {VALID_FIELD_TYPES}.")
     # Merge built-in fields (user redeclaration is rejected above)
     for name, spec in BUILTIN_FIELDS.items():
         if name not in fields:
@@ -181,37 +176,29 @@ def get_template_path(name: str) -> Path | None:
 
 
 def read_template(name: str) -> str:
-    """Read a bundled template by name, or exit with error."""
+    """Read a bundled template by name, or raise LnbError."""
     p = get_template_path(name)
     if p is None:
         names = [t[0] for t in list_templates()]
-        print(f"Error: unknown template '{name}'. Available: {', '.join(names)}",
-              file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Error: unknown template '{name}'. Available: {', '.join(names)}")
     return p.read_text()
 
 
 def read_template_from_path(path: str) -> str:
-    """Read a schema template from an external file path, or exit with error."""
+    """Read a schema template from an external file path, or raise LnbError."""
     p = Path(path)
     if not p.is_file():
-        print(f"Error: template path not found or not a file: {path}",
-              file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Error: template path not found or not a file: {path}")
     try:
         return p.read_text()
     except OSError as e:
-        print(f"Error: failed to read template at {path}: {e}",
-              file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Error: failed to read template at {path}: {e}")
 
 
 def print_templates() -> None:
     """Print available templates to stdout."""
     if not SCHEMAS_DIR.is_dir():
-        print("Error: schemas directory not found. Installation may be corrupt.",
-              file=sys.stderr)
-        sys.exit(1)
+        raise LnbError("Error: schemas directory not found. Installation may be corrupt.")
     templates = list_templates()
     if not templates:
         print("No templates found.")

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -13,7 +13,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-from .schema import CORE_FIELDS, RETRACT_TYPE, SchemaSQL, build_sql, load_schema
+from .schema import CORE_FIELDS, RETRACT_TYPE, LnbError, SchemaSQL, build_sql, load_schema
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,14 +65,13 @@ def get_notebook_dir(hint: str = "") -> Path:
         if val:
             return Path(val)
     # 3. Error
-    print("Error: LAB_NOTEBOOK_DIR is not set and no .lnb.env found.", file=sys.stderr)
+    msg = "Error: LAB_NOTEBOOK_DIR is not set and no .lnb.env found."
     if hint:
-        print(hint, file=sys.stderr)
+        msg += "\n" + hint
     else:
-        print("Set $LAB_NOTEBOOK_DIR, or run 'lab-notebook init' to create\n"
-              "a project-local notebook (writes .lnb.env in the current directory).",
-              file=sys.stderr)
-    sys.exit(1)
+        msg += ("\nSet $LAB_NOTEBOOK_DIR, or run 'lab-notebook init' to create\n"
+                "a project-local notebook (writes .lnb.env in the current directory).")
+    raise LnbError(msg)
 
 
 def get_writer_id() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from lab_notebook.schema import (
+    LnbError,
     build_sql,
     get_template_path,
     list_templates,
@@ -182,7 +183,7 @@ class TestSchema:
         assert schema["fields"]["tags"]["type"] == "list"
 
     def test_load_schema_missing_file(self, tmp_path):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             load_schema(tmp_path)
 
     def test_schema_fields_null(self, notebook):
@@ -198,21 +199,21 @@ class TestSchema:
         (notebook / "schema.yaml").write_text(
             "types:\n  - observation\nfields:\n  artifacts: {type: integer}\n"
         )
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             load_schema(notebook)
 
     def test_builtin_field_same_type_also_rejected(self, notebook):
         (notebook / "schema.yaml").write_text(
             "types:\n  - observation\nfields:\n  artifacts: {type: list}\n"
         )
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             load_schema(notebook)
 
     def test_schema_field_spec_not_dict(self, notebook):
         (notebook / "schema.yaml").write_text(
             "types:\n  - observation\nfields:\n  repo: text\n"
         )
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             load_schema(notebook)
 
     def test_build_sql_creates_custom_columns(self, custom_notebook):
@@ -247,6 +248,34 @@ class TestSchema:
         with pytest.raises(SystemExit):
             cmd_emit(make_custom_emit_args(type="milestone", content="Not allowed"))
         # 'milestone' is not in the custom schema's types list
+
+
+class TestErrorHandling:
+    """main() turns an LnbError raised anywhere below into exit 1 + stderr."""
+
+    def test_main_catches_lnberror_exits_1(self, tmp_path, monkeypatch, capsys):
+        # LAB_NOTEBOOK_DIR points at a dir with no schema.yaml, so load_schema
+        # (reached via 'schema') raises LnbError. main()'s single handler must
+        # print the message to stderr and exit 1 — same as the old sys.exit path.
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(tmp_path))
+        monkeypatch.setattr("sys.argv", ["lab-notebook", "schema"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "not found" in err
+        assert "lab-notebook init" in err
+
+    def test_main_lnberror_message_goes_to_stderr_not_stdout(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(tmp_path))
+        monkeypatch.setattr("sys.argv", ["lab-notebook", "schema"])
+        with pytest.raises(SystemExit):
+            main()
+        captured = capsys.readouterr()
+        assert "not found" in captured.err
+        assert "not found" not in captured.out
 
 
 # ---------------------------------------------------------------------------
@@ -810,7 +839,7 @@ class TestTemplateHelpers:
         assert "observation" in content
 
     def test_read_template_invalid(self):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             read_template("nonexistent")
 
     def test_print_templates(self, capsys):
@@ -834,16 +863,15 @@ class TestTemplateHelpers:
         p.write_text(body)
         assert read_template_from_path(str(p)) == body
 
-    def test_read_template_from_path_missing(self, tmp_path, capsys):
+    def test_read_template_from_path_missing(self, tmp_path):
         missing = tmp_path / "nope.yaml"
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError) as exc:
             read_template_from_path(str(missing))
-        err = capsys.readouterr().err
-        assert "not found" in err
-        assert str(missing) in err
+        assert "not found" in str(exc.value)
+        assert str(missing) in str(exc.value)
 
     def test_read_template_from_path_directory(self, tmp_path):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             read_template_from_path(str(tmp_path))
 
 
@@ -880,7 +908,7 @@ class TestCmdTemplate:
     def test_invalid_name(self, notebook):
         (notebook / "schema.yaml").unlink()
         args = argparse.Namespace(name="nonexistent", force=False)
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_template(args)
 
     def test_rebuild_hint_with_entries(self, notebook, capsys):
@@ -968,15 +996,14 @@ class TestInitTemplate:
         nb_dir = tmp_path / "nb" / ".lnb"
         assert (nb_dir / "schema.yaml").read_text() == custom.read_text()
 
-    def test_init_template_path_missing_file(self, tmp_path, monkeypatch, capsys):
+    def test_init_template_path_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         missing = tmp_path / "does-not-exist.yaml"
         args = argparse.Namespace(
             path=str(tmp_path / "nb"), template=None, template_path=str(missing))
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError) as exc:
             cmd_init(args)
-        err = capsys.readouterr().err
-        assert "not found" in err
+        assert "not found" in str(exc.value)
 
     def test_init_template_path_overwrites_existing(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -1306,7 +1333,7 @@ class TestRetract:
         assert "1 entries" in out
         assert "2 entries" not in out
 
-    def test_reserved_retract_type_rejected(self, notebook, capsys):
+    def test_reserved_retract_type_rejected(self, notebook):
         # A schema may not declare the reserved control-record type; doing so
         # would let emitted rows be silently swallowed as tombstones.
         (notebook / "schema.yaml").write_text(
@@ -1314,10 +1341,9 @@ class TestRetract:
             "  - observation\n"
             "  - _retract\n"
         )
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(LnbError) as exc:
             load_schema(notebook)
-        assert exc.value.code == 1
-        assert "_retract" in capsys.readouterr().err
+        assert "_retract" in str(exc.value)
 
     def test_pure_retract_pass_reports_retracted_count(self, notebook, capsys):
         cmd_emit(make_emit_args(content="to retract"))


### PR DESCRIPTION
## Summary

Second story in the cli.py rewrite (design context in REWRITE_HANDOFF.md, section "Error handling (US-002)"). Introduces a single user-facing exception type and centralizes exit handling in `main()`.

- Add `LnbError(Exception)` to `schema.py` (the lowest module).
- Convert every `print(..., file=sys.stderr); sys.exit(1)` pair in `schema.py` (11 sites) and `store.py` (`get_notebook_dir`) to `raise LnbError(msg)` with the **same message text**. The multi-line `get_notebook_dir` message is preserved by joining with newlines.
- `main()` wraps `args.func(args)` in exactly one `except LnbError` handler: prints `str(e)` to stderr, exits 1.
- Remove the now-unused `import sys` from `schema.py`.

## Out of scope (per handoff)

- Non-fatal warnings (malformed-line skip during ingest, index status messages) stay as stderr prints.
- `cli.py` `cmd_*` keep their own `sys.exit` — they become thin wrappers in US-003.

## Verification

- `grep` confirms no `sys.exit` remains in `schema.py` or `store.py`; exactly one `except LnbError` in `cli.py`.
- CLI smoke-tested: missing schema, unset `LAB_NOTEBOOK_DIR` (multi-line message preserved), and unknown template all print the identical message to stderr and exit 1.
- Tests: direct `schema`/`store` calls that raised `SystemExit` now assert `LnbError`; two new `TestErrorHandling` tests prove `main()` turns an `LnbError` into exit 1 with the message on stderr (not stdout).
- `uv run pytest -q`: **111 passed** (was 109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB