### PR TITLE
feat: US-003 - Introduce Notebook class API; cmd_* become thin wrappers

### DIFF
--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -15,18 +15,14 @@ from __future__ import annotations
 
 import argparse
 import csv
-import json
 import os
 import sqlite3
 import sys
-from datetime import datetime
 from pathlib import Path
 
 from .schema import (
     BUILTIN_FIELDS,
-    CORE_FIELDS,
     DEFAULT_TEMPLATE,
-    RETRACT_TYPE,
     LnbError,
     build_sql,
     format_schema_help,
@@ -37,14 +33,12 @@ from .schema import (
 )
 from .store import (
     LNB_ENV_FILE,
+    Notebook,
     _atomic_rebuild,
     _find_lnb_env,
     _parse_lnb_env,
-    ensure_db,
     entries_dir,
-    generate_id,
     get_notebook_dir,
-    get_writer_id,
     index_path,
 )
 
@@ -156,119 +150,53 @@ def cmd_init(args: argparse.Namespace) -> None:
 
 
 def cmd_emit(args: argparse.Namespace) -> None:
-    notebook_dir = get_notebook_dir()
-    writer_id = get_writer_id()
-    schema = getattr(args, "_schema", None) or load_schema(notebook_dir)
+    nb = Notebook(get_notebook_dir())
 
-    if args.type not in schema["types"]:
-        print(f"Error: type must be one of {schema['types']}, got '{args.type}'",
-              file=sys.stderr)
-        sys.exit(1)
-
-    entry = {
-        "id": generate_id(),
-        "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-        "writer_id": writer_id,
-        "context": args.context,
-        "type": args.type,
-        "content": args.content,
-    }
-
-    # Schema-defined fields
-    fields = schema.get("fields", {})
-    for name, spec in fields.items():
+    # Collect schema-field values from the parsed args (validation/coercion
+    # happens inside Notebook.emit, not here).
+    fields = {}
+    for name in nb.schema.get("fields", {}):
         val = getattr(args, name, None)
         if val is not None:
-            if spec["type"] == "list":
-                val = [v.strip() for v in val.split(",") if v.strip()]
-            elif spec["type"] == "integer":
-                val = int(val)
-            elif spec["type"] == "real":
-                val = float(val)
-        entry[name] = val
+            fields[name] = val
 
-    # --extra key=value pairs
-    reserved_keys = set(CORE_FIELDS) | set(fields.keys()) | {"extra"}
+    # Parse repeatable --extra KEY=VALUE strings into a dict; collision checks
+    # against declared fields are enforced by Notebook.emit.
+    extra: dict = {}
     if args.extra:
         for item in args.extra:
-            key, _, value = item.partition("=")
-            if not key or not _:
-                print(f"Error: --extra must be key=value, got '{item}'", file=sys.stderr)
-                sys.exit(1)
-            if key in reserved_keys:
-                print(f"Error: --extra key '{key}' conflicts with a declared field. "
-                      f"Use --{key} instead.", file=sys.stderr)
-                sys.exit(1)
-            entry[key] = value
+            key, sep, value = item.partition("=")
+            if not key or not sep:
+                raise LnbError(f"Error: --extra must be key=value, got '{item}'")
+            extra[key] = value
 
-    # Write JSONL
-    edir = entries_dir(notebook_dir)
-    edir.mkdir(exist_ok=True)
-    writer_file = edir / f"{writer_id}.jsonl"
-    with open(writer_file, "a") as f:
-        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        f.flush()
-        os.fsync(f.fileno())
-
+    entry = nb.emit(args.context, args.type, args.content,
+                    fields=fields, extra=extra)
     print(f"[{entry['type']}] {entry['id']}  {entry['context']}")
 
 
 def cmd_retract(args: argparse.Namespace) -> None:
-    notebook_dir = get_notebook_dir()
-    writer_id = get_writer_id()
-
-    # Confirm the target exists in the current index. A missing id means it was
-    # never written or has already been retracted — either way, nothing to do.
-    conn, schema, sql = ensure_db(notebook_dir)
+    nb = Notebook(get_notebook_dir())
     try:
-        found = conn.execute(
-            "SELECT id FROM entries WHERE id = ?", (args.id,)
-        ).fetchone()
+        nb.retract(args.id, args.reason)
     finally:
-        conn.close()
-    if not found:
-        print(f"Error: entry '{args.id}' not found "
-              f"(already retracted or never existed)", file=sys.stderr)
-        sys.exit(1)
-
-    tombstone = {
-        "id": generate_id(),
-        "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-        "writer_id": writer_id,
-        "type": RETRACT_TYPE,
-        "retracts": args.id,
-        "reason": args.reason,
-    }
-
-    # Append the tombstone to the retracting writer's own file. The deletion is
-    # applied on the next indexed read, the same way emit indexes lazily.
-    edir = entries_dir(notebook_dir)
-    edir.mkdir(exist_ok=True)
-    writer_file = edir / f"{writer_id}.jsonl"
-    with open(writer_file, "a") as f:
-        f.write(json.dumps(tombstone, ensure_ascii=False) + "\n")
-        f.flush()
-        os.fsync(f.fileno())
-
+        nb.close()
     print(f"[retracted] {args.id}  ({args.reason})")
 
 
 def cmd_sql(args: argparse.Namespace) -> None:
-    notebook_dir = get_notebook_dir()
-    conn, schema, sql = ensure_db(notebook_dir)
+    nb = Notebook(get_notebook_dir())
     try:
-        cursor = conn.execute(args.query)
+        cursor = nb.query(args.query)
         print_table(cursor)
     except sqlite3.OperationalError as e:
-        print(f"SQL error: {e}", file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"SQL error: {e}")
     finally:
-        conn.close()
+        nb.close()
 
 
 def cmd_search(args: argparse.Namespace) -> None:
-    notebook_dir = get_notebook_dir()
-    conn, schema, sql = ensure_db(notebook_dir)
+    nb = Notebook(get_notebook_dir())
     try:
         query_sql = """SELECT e.ts, e.context, e.type, e.writer_id, substr(e.content, 1, 120)
                  FROM entries e
@@ -282,13 +210,12 @@ def cmd_search(args: argparse.Namespace) -> None:
             query_sql += " AND e.type = :type"
             params["type"] = args.type
         query_sql += " ORDER BY e.ts DESC"
-        cursor = conn.execute(query_sql, params)
+        cursor = nb.query(query_sql, params)
         print_table(cursor)
     except sqlite3.OperationalError as e:
-        print(f"Search error: {e}", file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"Search error: {e}")
     finally:
-        conn.close()
+        nb.close()
 
 
 def cmd_schema(args: argparse.Namespace) -> None:
@@ -309,19 +236,17 @@ def cmd_rebuild(args: argparse.Namespace) -> None:
 
 
 def cmd_contexts(args: argparse.Namespace) -> None:
-    notebook_dir = get_notebook_dir()
-    conn, schema, sql = ensure_db(notebook_dir)
+    nb = Notebook(get_notebook_dir())
     try:
-        cursor = conn.execute("""\
+        cursor = nb.query("""\
             SELECT context, COUNT(*) AS entries, MIN(ts) AS first, MAX(ts) AS latest
             FROM entries GROUP BY context ORDER BY latest DESC
         """)
         print_table(cursor)
     except sqlite3.OperationalError as e:
-        print(f"SQL error: {e}", file=sys.stderr)
-        sys.exit(1)
+        raise LnbError(f"SQL error: {e}")
     finally:
-        conn.close()
+        nb.close()
 
 
 def cmd_template(args: argparse.Namespace) -> None:

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -305,6 +305,131 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
     return conn, schema, sql
 
 
+class Notebook:
+    """Programmatic API over a notebook directory.
+
+    All CLI commands are thin wrappers around this class. Field validation and
+    coercion live in `emit` (not in the CLI layer), so every caller — the CLI,
+    tests, or other Python code — gets the same enforcement.
+
+    The schema is loaded eagerly in `__init__`; a missing or invalid
+    `schema.yaml` raises `LnbError` up front.
+    """
+
+    def __init__(self, dir: Path):
+        """`dir` is the resolved notebook directory. Loads schema eagerly
+        (raises LnbError if schema.yaml is missing/invalid)."""
+        self.dir = Path(dir)
+        self.writer_id = get_writer_id()
+        self.schema = load_schema(self.dir)
+        self._conn: sqlite3.Connection | None = None
+
+    def _append(self, record: dict) -> None:
+        """Append one JSON record to the current writer's JSONL file, fsynced."""
+        edir = entries_dir(self.dir)
+        edir.mkdir(exist_ok=True)
+        writer_file = edir / f"{self.writer_id}.jsonl"
+        with open(writer_file, "a") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+    def emit(self, context: str, type: str, content: str,
+             fields: dict | None = None, extra: dict | None = None) -> dict:
+        """Validate type against schema, validate/coerce fields, append to the
+        writer's JSONL (fsync), return the entry dict.
+
+        `fields` maps schema field names to values. List fields accept either a
+        comma-separated string (CLI convention) or an already-split list;
+        integer/real fields are coerced. `extra` holds undeclared key/value
+        pairs; a key that collides with a core or schema field raises LnbError.
+        """
+        if type not in self.schema["types"]:
+            raise LnbError(
+                f"Error: type must be one of {self.schema['types']}, got '{type}'"
+            )
+
+        entry = {
+            "id": generate_id(),
+            "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "writer_id": self.writer_id,
+            "context": context,
+            "type": type,
+            "content": content,
+        }
+
+        schema_fields = self.schema.get("fields", {})
+        fields = fields or {}
+        for name, spec in schema_fields.items():
+            val = fields.get(name)
+            if val is not None:
+                if spec["type"] == "list":
+                    if isinstance(val, str):
+                        val = [v.strip() for v in val.split(",") if v.strip()]
+                elif spec["type"] == "integer":
+                    val = int(val)
+                elif spec["type"] == "real":
+                    val = float(val)
+            entry[name] = val
+
+        reserved_keys = set(CORE_FIELDS) | set(schema_fields.keys()) | {"extra"}
+        for key, value in (extra or {}).items():
+            if key in reserved_keys:
+                raise LnbError(
+                    f"Error: --extra key '{key}' conflicts with a declared field. "
+                    f"Use --{key} instead."
+                )
+            entry[key] = value
+
+        self._append(entry)
+        return entry
+
+    def retract(self, target_id: str, reason: str) -> dict:
+        """Verify the target exists in the index (LnbError if not), append a
+        tombstone to the writer's JSONL, and return the tombstone dict.
+
+        The deletion is applied lazily on the next indexed read, the same way
+        emit indexes lazily.
+        """
+        conn, _, _ = ensure_db(self.dir, self.schema)
+        try:
+            found = conn.execute(
+                "SELECT id FROM entries WHERE id = ?", (target_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        if not found:
+            raise LnbError(
+                f"Error: entry '{target_id}' not found "
+                f"(already retracted or never existed)"
+            )
+
+        tombstone = {
+            "id": generate_id(),
+            "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "writer_id": self.writer_id,
+            "type": RETRACT_TYPE,
+            "retracts": target_id,
+            "reason": reason,
+        }
+        self._append(tombstone)
+        return tombstone
+
+    def query(self, sql: str, params=()) -> sqlite3.Cursor:
+        """Ensure index freshness (incremental ingest / rebuild), then execute.
+        Caller is responsible for closing via `close()`."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+        self._conn, _, _ = ensure_db(self.dir, self.schema)
+        return self._conn.execute(sql, params)
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
 def rebuild_from_jsonl(conn: sqlite3.Connection, notebook_dir: Path,
                        schema: dict, sql: SchemaSQL) -> tuple[int, int]:
     """Clear the index and re-ingest every JSONL from byte 0.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from lab_notebook.schema import (
 )
 from lab_notebook.store import (
     LNB_ENV_FILE,
+    Notebook,
     _find_lnb_env,
     _parse_lnb_env,
     ensure_db,
@@ -245,7 +246,7 @@ class TestSchema:
         cmd_emit(make_custom_emit_args(type="result", content="A result"))
         # Should work: 'result' is in custom types
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_custom_emit_args(type="milestone", content="Not allowed"))
         # 'milestone' is not in the custom schema's types list
 
@@ -306,7 +307,7 @@ class TestEmit:
         assert rows[0][0] == "First entry"
 
     def test_type_validation(self, notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_emit_args(type="invalid-type"))
 
     def test_tags_and_artifacts(self, notebook):
@@ -406,19 +407,19 @@ class TestEmit:
         assert extra["num"] == "42"
 
     def test_extra_rejects_schema_field_collision(self, notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_emit_args(extra=["repo=sneaky"], content="Should fail"))
 
     def test_extra_rejects_core_field_collision(self, notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_emit_args(extra=["context=sneaky"], content="Should fail"))
 
     def test_extra_rejects_builtin_field_collision(self, notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_emit_args(extra=["artifacts=sneaky"], content="Should fail"))
 
     def test_extra_rejects_custom_schema_field_collision(self, custom_notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_emit(make_custom_emit_args(extra=["dataset=sneaky"], content="Should fail"))
 
     def test_extra_with_equals_in_value(self, notebook):
@@ -450,7 +451,7 @@ class TestSql:
         assert "no results" in out
 
     def test_invalid_sql(self, notebook):
-        with pytest.raises(SystemExit):
+        with pytest.raises(LnbError):
             cmd_sql(argparse.Namespace(query="NOT VALID SQL"))
 
     def test_query_custom_field(self, custom_notebook, capsys):
@@ -1261,20 +1262,18 @@ class TestRetract:
             main()
         assert exc.value.code == 2
 
-    def test_nonexistent_id_errors(self, notebook, capsys):
-        with pytest.raises(SystemExit) as exc:
+    def test_nonexistent_id_errors(self, notebook):
+        with pytest.raises(LnbError) as exc:
             cmd_retract(make_retract_args("20990101T000000-dead"))
-        assert exc.value.code == 1
-        assert "not found" in capsys.readouterr().err
+        assert "not found" in str(exc.value)
 
     def test_already_retracted_errors(self, notebook):
         cmd_emit(make_emit_args(content="retract twice"))
         target = _last_id_in_file(notebook, "test-writer.jsonl")
         cmd_retract(make_retract_args(target))
         # First retract is applied on the read inside the second retract.
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(LnbError):
             cmd_retract(make_retract_args(target))
-        assert exc.value.code == 1
 
     def test_cross_writer_retract_survives_rebuild(self, notebook, monkeypatch):
         # 'zoe' authors the entry; 'amy' retracts it. amy.jsonl sorts before
@@ -1368,3 +1367,64 @@ class TestRetract:
 
         ensure_db(notebook)[0].close()  # single pass: +1 add, -1 retract
         assert "Index updated: +1 entries, -1 retracted" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Notebook API (no argparse)
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookApi:
+    """Exercise the store.Notebook class directly, bypassing the CLI entirely."""
+
+    def test_emit_query_retract_roundtrip(self, notebook):
+        nb = Notebook(notebook)
+
+        # emit returns the entry dict with fields coerced by Notebook.emit
+        entry = nb.emit(
+            "api/ctx",
+            "observation",
+            "direct api entry",
+            fields={"repo": "lab", "tags": "alpha, beta"},
+            extra={"custom": "x"},
+        )
+        assert entry["content"] == "direct api entry"
+        assert entry["context"] == "api/ctx"
+        assert entry["repo"] == "lab"
+        assert entry["tags"] == ["alpha", "beta"]   # list field split from string
+        assert entry["custom"] == "x"               # extra field carried through
+        target_id = entry["id"]
+
+        # query sees the freshly-emitted entry (index built on demand)
+        cur = nb.query(
+            "SELECT content, repo FROM entries WHERE id = ?", (target_id,)
+        )
+        rows = cur.fetchall()
+        assert rows == [("direct api entry", "lab")]
+
+        # retract appends a tombstone targeting the entry
+        tomb = nb.retract(target_id, "no longer accurate")
+        assert tomb["type"] == "_retract"
+        assert tomb["retracts"] == target_id
+
+        # query again: the entry is gone (tombstone applied on the next read)
+        cur = nb.query("SELECT id FROM entries WHERE id = ?", (target_id,))
+        assert cur.fetchall() == []
+        nb.close()
+
+    def test_emit_rejects_unknown_type(self, notebook):
+        nb = Notebook(notebook)
+        with pytest.raises(LnbError):
+            nb.emit("api/ctx", "not-a-type", "content")
+        nb.close()
+
+    def test_retract_missing_target_raises(self, notebook):
+        nb = Notebook(notebook)
+        with pytest.raises(LnbError) as exc:
+            nb.retract("20990101T000000-dead", "reason")
+        assert "not found" in str(exc.value)
+        nb.close()
+
+    def test_init_missing_schema_raises(self, tmp_path):
+        with pytest.raises(LnbError):
+            Notebook(tmp_path)


### PR DESCRIPTION
## What

Introduces a `Notebook` class in `store.py` as the programmatic API over a notebook directory, and rewrites the CLI commands as thin wrappers around it.

`store.Notebook`:
- `__init__(dir)` — resolves the dir and loads the schema eagerly (raises `LnbError` if `schema.yaml` is missing/invalid)
- `emit(context, type, content, fields=None, extra=None) -> dict` — validates the type, validates/coerces schema fields (list-splitting, int/real), enforces the `--extra` collision check, appends to the writer's JSONL (fsync), returns the entry
- `retract(target_id, reason) -> dict` — verifies the target exists in the index (`LnbError` if not), appends a tombstone, returns it
- `query(sql, params=()) -> sqlite3.Cursor` — ensures index freshness, executes; caller closes via `close()`
- `close()`

`cmd_emit`, `cmd_retract`, `cmd_sql`, `cmd_search`, `cmd_contexts` are now thin: parse args → construct `Notebook` → call a method → format output. Field validation/coercion moved out of `cmd_emit` into `Notebook.emit`, so it is enforced for every caller.

## Error handling

Following the US-002 architecture (single `except LnbError` in `main()`), the former `print+sys.exit` sites in these commands now raise `LnbError`: emit type/`--extra` validation, `sql`/`search`/`contexts` SQL errors, and retract not-found. User-facing behavior (messages, exit code 1) is unchanged.

## Tests

- New `TestNotebookApi` exercises the class directly with no argparse: emit → query → retract → query-again roundtrip, plus unknown-type, missing-target, and missing-schema error cases.
- Nine existing `SystemExit` assertions on direct `cmd_*` calls updated to `LnbError` (per the US-002 test convention).
- Full suite: `115 passed` (was 111).

Dependency direction remains `cli -> store -> schema`. JSONL on-disk format is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB