### PR TITLE
feat: US-004 - Switch to external-content FTS5 with triggers

### DIFF
--- a/src/lab_notebook/schema.py
+++ b/src/lab_notebook/schema.py
@@ -22,7 +22,14 @@ BUILTIN_FIELDS = {"artifacts": {"type": "list"}}  # always present, nullable; me
 VALID_FIELD_TYPES = ("text", "integer", "real", "list")
 TYPE_MAP = {"text": "TEXT", "integer": "INTEGER", "real": "REAL", "list": "TEXT"}
 
-SchemaSQL = namedtuple("SchemaSQL", ["create", "upsert", "fts_insert", "fts_cols"])
+# Index layout version, stamped into the SQLite index via PRAGMA user_version.
+# ensure_db forces a full rebuild when an existing index's version differs, so
+# bumping this transparently migrates old indexes (they are disposable).
+#   1 = standalone entries_fts, manual sync in upsert_entry/delete_entry
+#   2 = external-content entries_fts kept in sync by triggers (US-004)
+INDEX_USER_VERSION = 2
+
+SchemaSQL = namedtuple("SchemaSQL", ["create", "upsert", "fts_cols"])
 
 
 def format_schema_help(schema: dict) -> str:
@@ -108,18 +115,45 @@ def build_sql(schema: dict) -> SchemaSQL:
         if spec.get("fts"):
             fts_cols.append(name)
 
+    # entries_fts is an external-content FTS5 table: it stores no copy of the
+    # text itself, only the inverted index, and reads column values back from
+    # `entries` by rowid. Triggers keep the index in sync — AFTER INSERT adds
+    # postings, AFTER DELETE removes them via the fts5 'delete' command (which
+    # needs the *old* column values to locate the tokens), and AFTER UPDATE
+    # does both. INSERT OR REPLACE in upsert_entry fires delete+insert; a plain
+    # DELETE in delete_entry fires the delete trigger. (For REPLACE's implicit
+    # delete to fire its trigger, the ingest connection must run with
+    # PRAGMA recursive_triggers = ON — see store.py.)
+    fts_col_list = ", ".join(f'"{c}"' for c in fts_cols)
+    new_vals = ", ".join(f'new."{c}"' for c in fts_cols)
+    old_vals = ", ".join(f'old."{c}"' for c in fts_cols)
+
     create_sql = (
         f"CREATE TABLE IF NOT EXISTS entries (\n    "
         + ",\n    ".join(col_defs)
         + "\n);\n"
         + "CREATE VIRTUAL TABLE IF NOT EXISTS entries_fts USING fts5("
-        + ", ".join(f'"{c}"' for c in fts_cols)
-        + ");\n"
+        + f"{fts_col_list}, content='entries', content_rowid='rowid');\n"
+        + "CREATE TRIGGER IF NOT EXISTS entries_ai AFTER INSERT ON entries BEGIN\n"
+        + f"    INSERT INTO entries_fts(rowid, {fts_col_list}) "
+        + f"VALUES (new.rowid, {new_vals});\n"
+        + "END;\n"
+        + "CREATE TRIGGER IF NOT EXISTS entries_ad AFTER DELETE ON entries BEGIN\n"
+        + f"    INSERT INTO entries_fts(entries_fts, rowid, {fts_col_list}) "
+        + f"VALUES ('delete', old.rowid, {old_vals});\n"
+        + "END;\n"
+        + "CREATE TRIGGER IF NOT EXISTS entries_au AFTER UPDATE ON entries BEGIN\n"
+        + f"    INSERT INTO entries_fts(entries_fts, rowid, {fts_col_list}) "
+        + f"VALUES ('delete', old.rowid, {old_vals});\n"
+        + f"    INSERT INTO entries_fts(rowid, {fts_col_list}) "
+        + f"VALUES (new.rowid, {new_vals});\n"
+        + "END;\n"
         + "CREATE INDEX IF NOT EXISTS idx_entries_context ON entries(context);\n"
         + "CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);\n"
         + "CREATE INDEX IF NOT EXISTS idx_entries_ts ON entries(ts);\n"
         + "CREATE TABLE IF NOT EXISTS _ingest_state ("
         + "file TEXT PRIMARY KEY, offset INTEGER NOT NULL);\n"
+        + f"PRAGMA user_version = {INDEX_USER_VERSION};\n"
     )
 
     # -- UPSERT --
@@ -133,16 +167,7 @@ def build_sql(schema: dict) -> SchemaSQL:
         f"    ({placeholders});\n"
     )
 
-    # -- FTS INSERT --
-    quoted_fts = ", ".join(f'"{c}"' for c in fts_cols)
-    fts_placeholders = ", ".join(f":{c}" for c in fts_cols)
-    fts_insert_sql = (
-        f"INSERT INTO entries_fts (rowid, {quoted_fts})\n"
-        f"VALUES (:rowid, {fts_placeholders});\n"
-    )
-
-    return SchemaSQL(create=create_sql, upsert=upsert_sql,
-                     fts_insert=fts_insert_sql, fts_cols=fts_cols)
+    return SchemaSQL(create=create_sql, upsert=upsert_sql, fts_cols=fts_cols)
 
 
 # ---------------------------------------------------------------------------

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -13,7 +13,15 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-from .schema import CORE_FIELDS, RETRACT_TYPE, LnbError, SchemaSQL, build_sql, load_schema
+from .schema import (
+    CORE_FIELDS,
+    INDEX_USER_VERSION,
+    RETRACT_TYPE,
+    LnbError,
+    SchemaSQL,
+    build_sql,
+    load_schema,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -93,6 +101,30 @@ def index_path(notebook_dir: Path) -> Path:
     return notebook_dir / "index.sqlite"
 
 
+def _connect(dbp: Path) -> sqlite3.Connection:
+    """Open the index with recursive_triggers ON.
+
+    entries_fts is kept in sync by triggers on entries. INSERT OR REPLACE in
+    upsert_entry deletes the replaced row before inserting the new one, but that
+    implicit delete only fires the AFTER DELETE trigger when recursive_triggers
+    is enabled. Without it, the replaced row's FTS postings orphan in the index
+    and can corrupt search once SQLite reuses the freed rowid. Every connection
+    that may write to entries goes through here.
+    """
+    conn = sqlite3.connect(str(dbp))
+    conn.execute("PRAGMA recursive_triggers = ON")
+    return conn
+
+
+def _index_user_version(dbp: Path) -> int:
+    """Return the index's stamped layout version (0 for indexes predating it)."""
+    conn = sqlite3.connect(str(dbp))
+    try:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
 def flatten_entry(entry: dict, schema: dict) -> dict:
     fields = schema.get("fields", {})
     list_fields = {name for name, spec in fields.items() if spec["type"] == "list"}
@@ -118,33 +150,23 @@ def flatten_entry(entry: dict, schema: dict) -> dict:
 
 def upsert_entry(conn: sqlite3.Connection, entry: dict, sql: SchemaSQL,
                   commit: bool = True) -> None:
+    # entries_fts is external-content and kept in sync by triggers on entries.
+    # INSERT OR REPLACE fires the delete trigger (for the replaced row) and the
+    # insert trigger (for the new row); the connection must have
+    # recursive_triggers ON so REPLACE's implicit delete fires — see ensure_db.
     conn.execute(sql.upsert, entry)
-    row = conn.execute(
-        "SELECT rowid FROM entries WHERE id = :id", {"id": entry["id"]}
-    ).fetchone()
-    if row:
-        rowid = row[0]
-        conn.execute("DELETE FROM entries_fts WHERE rowid = ?", (rowid,))
-        fts_params = {"rowid": rowid}
-        for col in sql.fts_cols:
-            fts_params[col] = entry.get(col, "")
-        conn.execute(sql.fts_insert, fts_params)
     if commit:
         conn.commit()
 
 
 def delete_entry(conn: sqlite3.Connection, target_id: str) -> bool:
-    """Hard-delete a target entry and its FTS row. No-op if it isn't present
-    (already retracted, or the tombstone references an id that never existed).
-    Returns True if a row was actually removed, False on the no-op path."""
-    row = conn.execute(
-        "SELECT rowid FROM entries WHERE id = ?", (target_id,)
-    ).fetchone()
-    if row:
-        conn.execute("DELETE FROM entries_fts WHERE rowid = ?", (row[0],))
-        conn.execute("DELETE FROM entries WHERE id = ?", (target_id,))
-        return True
-    return False
+    """Hard-delete a target entry. The AFTER DELETE trigger keeps entries_fts in
+    sync. No-op if it isn't present (already retracted, or the tombstone
+    references an id that never existed). Returns True if a row was actually
+    removed, False on the no-op path."""
+    return conn.execute(
+        "DELETE FROM entries WHERE id = ?", (target_id,)
+    ).rowcount > 0
 
 
 def _atomic_rebuild(notebook_dir: Path, dbp: Path,
@@ -153,7 +175,7 @@ def _atomic_rebuild(notebook_dir: Path, dbp: Path,
     fd, tmp = tempfile.mkstemp(dir=str(notebook_dir), suffix='.sqlite')
     os.close(fd)
     try:
-        conn = sqlite3.connect(tmp)
+        conn = _connect(Path(tmp))
         conn.executescript(sql.create)
         rebuild_from_jsonl(conn, notebook_dir, schema, sql)
         # Report the net active count (rows actually in the index after
@@ -276,11 +298,19 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
         schema = load_schema(notebook_dir)
     sql = build_sql(schema)
     dbp = index_path(notebook_dir)
-    if not dbp.exists() or _schema_newer_than_index(notebook_dir, dbp):
+    # Rebuild from scratch when the index is missing, older than the schema, or
+    # written in a prior index layout (user_version mismatch). The index is
+    # disposable, so a version bump migrates old indexes transparently.
+    stale = (
+        not dbp.exists()
+        or _schema_newer_than_index(notebook_dir, dbp)
+        or _index_user_version(dbp) != INDEX_USER_VERSION
+    )
+    if stale:
         count = _atomic_rebuild(notebook_dir, dbp, schema, sql)
         print(f"Index rebuilt: {count} entries", file=sys.stderr)
     else:
-        conn = sqlite3.connect(str(dbp))
+        conn = _connect(dbp)
         fence_tripped = None
         added = retracted = 0
         try:
@@ -301,7 +331,7 @@ def ensure_db(notebook_dir: Path, schema: dict | None = None) -> tuple[sqlite3.C
             print(f"Index updated: +{added} entries", file=sys.stderr)
         elif retracted:
             print(f"Index updated: -{retracted} retracted", file=sys.stderr)
-    conn = sqlite3.connect(str(dbp))
+    conn = _connect(dbp)
     return conn, schema, sql
 
 
@@ -434,15 +464,16 @@ def rebuild_from_jsonl(conn: sqlite3.Connection, notebook_dir: Path,
                        schema: dict, sql: SchemaSQL) -> tuple[int, int]:
     """Clear the index and re-ingest every JSONL from byte 0.
 
-    Implemented by clearing entries/entries_fts/_ingest_state and delegating
-    to incremental_ingest. That gets EOF-safe offset bookkeeping for free,
-    so a fresh index ends with _ingest_state populated to current file sizes.
+    Implemented by clearing entries/_ingest_state and delegating to
+    incremental_ingest. That gets EOF-safe offset bookkeeping for free, so a
+    fresh index ends with _ingest_state populated to current file sizes.
+    Deleting the entries rows fires the AFTER DELETE trigger, which clears the
+    external-content entries_fts in step (no separate FTS delete needed).
     """
     edir = entries_dir(notebook_dir)
     if not edir.exists():
         return 0, 0
     conn.execute("DELETE FROM entries")
-    conn.execute("DELETE FROM entries_fts")
     conn.execute("DELETE FROM _ingest_state")
     conn.commit()
     return incremental_ingest(conn, notebook_dir, schema, sql)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from lab_notebook.schema import (
+    INDEX_USER_VERSION,
     LnbError,
     build_sql,
     get_template_path,
@@ -24,6 +25,7 @@ from lab_notebook.store import (
     LNB_ENV_FILE,
     Notebook,
     _find_lnb_env,
+    _index_user_version,
     _parse_lnb_env,
     ensure_db,
     entries_dir,
@@ -771,6 +773,47 @@ class TestIncrementalIngest:
         assert self._read_offset(notebook, a_file.name) == a_offset_before
         assert self._read_offset(notebook, b_file.name) > b_offset_before
         assert self._read_offset(notebook, b_file.name) == b_file.stat().st_size
+
+
+# ---------------------------------------------------------------------------
+# index versioning (US-004)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexVersion:
+    def test_fresh_index_is_stamped_with_current_version(self, notebook):
+        cmd_emit(make_emit_args(content="stamp me"))
+        ensure_db(notebook)[0].close()
+        assert _index_user_version(index_path(notebook)) == INDEX_USER_VERSION
+
+    def test_old_format_index_forces_rebuild(self, notebook, capsys):
+        # Build a current index, then simulate a pre-existing old-format index by
+        # rewinding its stamped layout version. Any read via ensure_db must
+        # notice the mismatch and rebuild from the JSONL (the source of truth),
+        # then re-stamp the current version — after which FTS search still works.
+        cmd_emit(make_emit_args(content="rebuildable token"))
+        ensure_db(notebook)[0].close()
+        dbp = index_path(notebook)
+        conn = sqlite3.connect(str(dbp))
+        conn.execute("PRAGMA user_version = 1")  # pretend the old layout
+        conn.commit()
+        conn.close()
+        assert _index_user_version(dbp) == 1
+
+        capsys.readouterr()  # clear
+        conn, _, _ = ensure_db(notebook)
+        err = capsys.readouterr().err
+        try:
+            assert "Index rebuilt" in err
+            assert _index_user_version(dbp) == INDEX_USER_VERSION
+            hit = conn.execute(
+                "SELECT e.content FROM entries e "
+                "JOIN entries_fts f ON f.rowid = e.rowid "
+                "WHERE entries_fts MATCH 'rebuildable'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert hit == [("rebuildable token",)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## US-004: Switch to external-content FTS5 with triggers

Replaces the standalone `entries_fts` table + manual sync with an **external-content FTS5** table kept in sync by triggers.

### Changes
- **`build_sql`** emits `CREATE VIRTUAL TABLE entries_fts USING fts5(<cols>, content='entries', content_rowid='rowid')` plus `AFTER INSERT / AFTER DELETE / AFTER UPDATE` triggers (fts5 `'delete'` command pattern), and stamps `PRAGMA user_version = 2` into the DDL.
- **`upsert_entry`** collapses to a single `INSERT OR REPLACE`; **`delete_entry`** to a single `DELETE`. The manual FTS delete/re-insert code is gone. `SchemaSQL` drops the now-dead `fts_insert` member (`fts_cols` kept — still used by the trigger builder and a test).
- **`ensure_db`** forces a full rebuild when an existing index's `user_version` differs from `INDEX_USER_VERSION`, transparently migrating old-layout indexes (the index is disposable).
- **`recursive_triggers = ON`** on ingest/query connections (new `_connect` helper). This is required: `INSERT OR REPLACE`'s implicit delete only fires the `AFTER DELETE` trigger when recursive triggers are enabled — otherwise the replaced row's FTS postings orphan in the index and corrupt search once SQLite reuses the freed rowid (verified empirically).
- **`rebuild_from_jsonl`** no longer issues `DELETE FROM entries_fts`; deleting the `entries` rows fires the delete trigger, which clears the external-content index.

### Tests
- New `TestIndexVersion`: a fresh index is stamped `user_version=2`; an old-format index (version rewound to 1) forces an auto-rebuild via `ensure_db`, re-stamps the current version, and FTS search still works afterward.
- Existing FTS / search / retract tests pass unchanged, including search-after-retract showing the entry gone.
- `uv run pytest -q`: **117 passed** (was 115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB