### PR TITLE
feat: US-005 - init literal path semantics and --force for .lnb.env overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,18 @@ Run `lab-notebook rebuild` after changing `schema.yaml`.
 
 ## Commands
 
-### `init [path] [--template NAME | --template-path PATH]`
+### `init [path] [--template NAME | --template-path PATH] [--force]`
 
-Initialize a project-local notebook. Creates `.lnb/` in the current directory
-(or at `path` if given) with `entries/`, `artifacts/`, `schema.yaml`, and
-`.gitignore`. Also writes `.lnb.env` in the current directory for automatic
-notebook discovery. Use `--template` to pick a bundled schema template (default:
-`research-notebook`). Pass `--template` with no value to list available
-templates. Use `--template-path PATH` to load a schema from an arbitrary YAML
-file on disk (mutually exclusive with `--template`).
+Initialize a project-local notebook. With no argument, creates `./.lnb/` in the
+current directory; given a `path`, creates the notebook at exactly that path
+(the path is used verbatim — nothing is appended). Either way the directory is
+populated with `entries/`, `artifacts/`, `schema.yaml`, and `.gitignore`. Also
+writes `.lnb.env` in the current directory for automatic notebook discovery; if
+`.lnb.env` already exists, `init` refuses unless `--force` is given. Use
+`--template` to pick a bundled schema template (default: `research-notebook`).
+Pass `--template` with no value to list available templates. Use
+`--template-path PATH` to load a schema from an arbitrary YAML file on disk
+(mutually exclusive with `--template`).
 
 ### `emit --context X --type Y [--artifacts ...] [--field ...] [--extra K=V] "content"`
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -56,7 +56,7 @@ The index is rebuilt incrementally on read. The first command after new entries 
 
 ## Init
 
-Project-local notebook setup. The CLI creates a `.lnb.env` file in the current directory and a notebook at `.lnb/` (the CLI always creates the `.lnb/` subdirectory inside the path you give, defaulting to the current directory). All `lab-notebook` commands then auto-discover it.
+Project-local notebook setup. The CLI creates a `.lnb.env` file in the current directory and a notebook directory (`./.lnb` by default, or exactly the path you give). All `lab-notebook` commands then auto-discover it.
 
 ### Step 1: Pick a notebook path
 
@@ -70,10 +70,10 @@ Ask:
 lab-notebook init [<path>]
 ```
 
-Omit `<path>` to use the default `./.lnb/`. The CLI always creates a `.lnb/` subdirectory inside the given path, so `<path>` becomes `<path>/.lnb/`. The CLI will:
-- Create the notebook directory (`<path>/.lnb/`) with `entries/`, `artifacts/`, `schema.yaml`, `.gitignore`
+Omit `<path>` to use the default `./.lnb`. An explicit `<path>` is used verbatim — nothing is appended. The CLI will:
+- Create the notebook directory (`./.lnb`, or exactly `<path>`) with `entries/`, `artifacts/`, `schema.yaml`, `.gitignore`
 - Write `.lnb.env` in the current directory
-- Warn if `.lnb.env` already exists (overwrites it)
+- Refuse if `.lnb.env` already exists — pass `--force` to overwrite it
 
 If the command fails, show the error and stop.
 
@@ -142,20 +142,20 @@ Set `LAB_NOTEBOOK_WRITER` only if they provide a value different from `$USER`.
 
 ### Step 2: Initialize the notebook
 
-First check if the notebook already exists. The CLI always creates a `.lnb/` subdirectory inside the given path. Check both locations to handle re-runs (where `LAB_NOTEBOOK_DIR` already ends in `.lnb`):
+First check if the notebook already exists. The CLI uses the given path verbatim, so the notebook lives directly at `$LAB_NOTEBOOK_DIR`:
 
 ```bash
-(test -f "$LAB_NOTEBOOK_DIR/schema.yaml" || test -f "$LAB_NOTEBOOK_DIR/.lnb/schema.yaml") && echo "EXISTS" || echo "NEW"
+test -f "$LAB_NOTEBOOK_DIR/schema.yaml" && echo "EXISTS" || echo "NEW"
 ```
 
 - If `EXISTS`: tell the user "Notebook already initialized — skipping init." Proceed to Step 3.
-- If `NEW`: run:
+- If `NEW`: run (`--force` lets init overwrite any `.lnb.env` left in the current directory, which global setup discards anyway):
 
 ```bash
-lab-notebook init "$LAB_NOTEBOOK_DIR"
+lab-notebook init "$LAB_NOTEBOOK_DIR" --force
 ```
 
-This creates the notebook at `$LAB_NOTEBOOK_DIR/.lnb/` and writes `.lnb.env` in the current directory. Since this is global setup, the `.lnb.env` file is not needed — clean it up:
+This creates the notebook at `$LAB_NOTEBOOK_DIR` and writes `.lnb.env` in the current directory. Since this is global setup, the `.lnb.env` file is not needed — clean it up:
 
 ```bash
 rm -f .lnb.env
@@ -169,16 +169,16 @@ Do not proceed past this step on failure.
 
 ### Step 3: Set and persist the environment
 
-The notebook lives at `<chosen path>/.lnb/`, so the env var must point there. Export in the current session:
+The notebook lives at exactly `<chosen path>` (the same value set in Step 1), so the env var already points there. Confirm it's exported in the current session:
 
 ```bash
-export LAB_NOTEBOOK_DIR="<chosen path>/.lnb"
+export LAB_NOTEBOOK_DIR="<chosen path>"
 ```
 
 Then tell the user to add to their shell profile (or a project `.env`) for future sessions:
 
 ```bash
-export LAB_NOTEBOOK_DIR="<chosen path>/.lnb"
+export LAB_NOTEBOOK_DIR="<chosen path>"
 export LAB_NOTEBOOK_WRITER="<username>"  # optional, defaults to $USER
 ```
 

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -86,7 +86,18 @@ def cmd_init(args: argparse.Namespace) -> None:
         print_templates()
         return
 
-    target = (Path(args.path or ".") / ".lnb").resolve()
+    # Refuse to clobber an existing .lnb.env unless --force (matches the
+    # `template` command's convention). Checked up front so we fail before
+    # creating any notebook directory.
+    lnb_env = Path.cwd() / LNB_ENV_FILE
+    if lnb_env.exists() and not getattr(args, "force", False):
+        raise LnbError(
+            f"Error: {lnb_env} already exists. Use --force to overwrite."
+        )
+
+    # Literal path semantics: no arg -> ./.lnb; an explicit path is used as-is
+    # (no .lnb appended).
+    target = (Path(".") / ".lnb" if args.path is None else Path(args.path)).resolve()
     target.mkdir(parents=True, exist_ok=True)
 
     template_path = getattr(args, "template_path", None)
@@ -128,10 +139,7 @@ def cmd_init(args: argparse.Namespace) -> None:
 
     writer = os.environ.get("USER", "unknown")
 
-    # Write .lnb.env in CWD
-    lnb_env = Path.cwd() / LNB_ENV_FILE
-    if lnb_env.exists():
-        print(f"Warning: overwriting existing {lnb_env}", file=sys.stderr)
+    # Write .lnb.env in CWD (existence guarded above; --force overwrites).
     lnb_env.write_text(
         f"# Project-local lab-notebook configuration\n"
         f"export LAB_NOTEBOOK_DIR={target}\n"
@@ -289,6 +297,8 @@ def main() -> None:
                         help="Bundled schema template (omit value to list available templates)")
     tgroup.add_argument("--template-path", default=None, metavar="PATH",
                         help="Load schema from a YAML file on disk")
+    p_init.add_argument("--force", action="store_true",
+                        help="Overwrite an existing .lnb.env in the current directory")
     p_init.set_defaults(func=cmd_init)
 
     # -- emit --

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def notebook(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
     cmd_init(args)
-    nb_dir = tmp_path / "nb" / ".lnb"
+    nb_dir = tmp_path / "nb"
     monkeypatch.setenv("LAB_NOTEBOOK_DIR", str(nb_dir))
     monkeypatch.setenv("LAB_NOTEBOOK_WRITER", "test-writer")
     return nb_dir
@@ -65,7 +65,7 @@ def custom_notebook(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
     cmd_init(args)
-    nb_dir = tmp_path / "nb" / ".lnb"
+    nb_dir = tmp_path / "nb"
     # Overwrite schema.yaml with custom fields
     (nb_dir / "schema.yaml").write_text(
         "types:\n"
@@ -126,7 +126,7 @@ class TestInit:
         args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
         cmd_init(args)
 
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         assert nb_dir.is_dir()
         assert (nb_dir / "entries").is_dir()
         assert (nb_dir / "artifacts").is_dir()
@@ -144,7 +144,7 @@ class TestInit:
         args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
         cmd_init(args)
 
-        sf = tmp_path / "nb" / ".lnb" / "schema.yaml"
+        sf = tmp_path / "nb" / "schema.yaml"
         assert sf.exists()
         import yaml
         schema = yaml.safe_load(sf.read_text())
@@ -167,10 +167,51 @@ class TestInit:
         monkeypatch.chdir(tmp_path)
         args = argparse.Namespace(path=str(tmp_path / "proj"), template=None)
         cmd_init(args)
-        nb_dir = tmp_path / "proj" / ".lnb"
+        nb_dir = tmp_path / "proj"
         assert nb_dir.is_dir()
         assert (nb_dir / "entries").is_dir()
         assert (tmp_path / LNB_ENV_FILE).exists()
+
+    def test_init_explicit_path_is_literal(self, tmp_path, monkeypatch):
+        # An explicit path is used verbatim — no ".lnb" is appended.
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "notes"
+        args = argparse.Namespace(path=str(target), template=None)
+        cmd_init(args)
+        assert (target / "schema.yaml").exists()
+        assert (target / "entries").is_dir()
+        # The old appending behavior would have created target/.lnb — it must not.
+        assert not (target / ".lnb").exists()
+        # .lnb.env points at the literal path.
+        assert f"LAB_NOTEBOOK_DIR={target}" in (tmp_path / LNB_ENV_FILE).read_text()
+
+    def test_init_no_arg_creates_dot_lnb(self, tmp_path, monkeypatch):
+        # No path arg -> ./.lnb in the current directory.
+        monkeypatch.chdir(tmp_path)
+        cmd_init(argparse.Namespace(path=None, template=None))
+        assert (tmp_path / ".lnb" / "schema.yaml").exists()
+
+    def test_init_refuses_existing_lnb_env(self, tmp_path, monkeypatch):
+        # A second init in the same directory refuses to clobber .lnb.env.
+        monkeypatch.chdir(tmp_path)
+        cmd_init(argparse.Namespace(path=str(tmp_path / "a"), template=None))
+        with pytest.raises(LnbError) as exc:
+            cmd_init(argparse.Namespace(path=str(tmp_path / "b"), template=None))
+        assert "already exists" in str(exc.value)
+        assert LNB_ENV_FILE in str(exc.value)
+        # The refused run must not have repointed .lnb.env at "b".
+        env_text = (tmp_path / LNB_ENV_FILE).read_text()
+        assert str(tmp_path / "a") in env_text
+        assert str(tmp_path / "b") not in env_text
+
+    def test_init_force_overwrites_lnb_env(self, tmp_path, monkeypatch):
+        # --force lets a second init repoint .lnb.env.
+        monkeypatch.chdir(tmp_path)
+        cmd_init(argparse.Namespace(path=str(tmp_path / "a"), template=None))
+        cmd_init(argparse.Namespace(
+            path=str(tmp_path / "b"), template=None, force=True))
+        env_text = (tmp_path / LNB_ENV_FILE).read_text()
+        assert f"LAB_NOTEBOOK_DIR={tmp_path / 'b'}" in env_text
 
 
 # ---------------------------------------------------------------------------
@@ -971,7 +1012,7 @@ class TestInitTemplate:
         args = argparse.Namespace(path=str(tmp_path / "nb"), template="ml-experiment-log")
         cmd_init(args)
         import yaml
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
         assert "run-start" in schema["types"]
         assert "method" in schema["fields"]
@@ -985,28 +1026,29 @@ class TestInitTemplate:
 
     def test_init_template_overwrites_existing(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         # First init with default
         args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
         cmd_init(args)
         import yaml
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
         assert "observation" in schema["types"]
-        # Re-init with explicit template
-        args = argparse.Namespace(path=str(tmp_path / "nb"), template="ml-experiment-log")
+        # Re-init with explicit template (--force to overwrite .lnb.env)
+        args = argparse.Namespace(
+            path=str(tmp_path / "nb"), template="ml-experiment-log", force=True)
         cmd_init(args)
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
         assert "run-start" in schema["types"]
 
     def test_init_no_template_keeps_existing(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
         cmd_init(args)
         # Overwrite schema with custom content
         (nb_dir / "schema.yaml").write_text("types:\n  - custom\nfields:\n")
-        # Re-init without --template
-        args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
+        # Re-init without --template (--force to overwrite .lnb.env)
+        args = argparse.Namespace(path=str(tmp_path / "nb"), template=None, force=True)
         cmd_init(args)
         import yaml
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
@@ -1019,13 +1061,14 @@ class TestInitTemplate:
         cmd_init(args)
         out = capsys.readouterr().out
         assert "from template: research-notebook" in out
-        # Re-init without template — should say "kept"
-        args = argparse.Namespace(path=str(tmp_path / "nb"), template=None)
+        # Re-init without template — should say "kept" (--force to overwrite .lnb.env)
+        args = argparse.Namespace(path=str(tmp_path / "nb"), template=None, force=True)
         cmd_init(args)
         out = capsys.readouterr().out
         assert "already exists (kept)" in out
-        # Re-init with explicit template — should say "overwritten"
-        args = argparse.Namespace(path=str(tmp_path / "nb"), template="ml-experiment-log")
+        # Re-init with explicit template — should say "overwritten" (--force to overwrite .lnb.env)
+        args = argparse.Namespace(
+            path=str(tmp_path / "nb"), template="ml-experiment-log", force=True)
         cmd_init(args)
         out = capsys.readouterr().out
         assert "overwritten" in out
@@ -1037,7 +1080,7 @@ class TestInitTemplate:
         args = argparse.Namespace(
             path=str(tmp_path / "nb"), template=None, template_path=str(custom))
         cmd_init(args)
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         assert (nb_dir / "schema.yaml").read_text() == custom.read_text()
 
     def test_init_template_path_missing_file(self, tmp_path, monkeypatch):
@@ -1051,7 +1094,7 @@ class TestInitTemplate:
 
     def test_init_template_path_overwrites_existing(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        nb_dir = tmp_path / "nb" / ".lnb"
+        nb_dir = tmp_path / "nb"
         # First init with default
         args = argparse.Namespace(
             path=str(tmp_path / "nb"), template=None, template_path=None)
@@ -1059,11 +1102,12 @@ class TestInitTemplate:
         import yaml
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
         assert "observation" in schema["types"]
-        # Re-init with --template-path
+        # Re-init with --template-path (--force to overwrite .lnb.env)
         custom = tmp_path / "custom.yaml"
         custom.write_text("types:\n  - note\nfields: {}\n")
         args = argparse.Namespace(
-            path=str(tmp_path / "nb"), template=None, template_path=str(custom))
+            path=str(tmp_path / "nb"), template=None, template_path=str(custom),
+            force=True)
         cmd_init(args)
         schema = yaml.safe_load((nb_dir / "schema.yaml").read_text())
         assert schema["types"] == ["note"]
@@ -1213,7 +1257,7 @@ class TestInitDefault:
         monkeypatch.chdir(tmp_path)
         args = argparse.Namespace(path="my-project", template=None)
         cmd_init(args)
-        nb_dir = tmp_path / "my-project" / ".lnb"
+        nb_dir = tmp_path / "my-project"
         assert nb_dir.is_dir()
         lnb_env = tmp_path / LNB_ENV_FILE
         content = lnb_env.read_text()


### PR DESCRIPTION
## US-005: `init` literal path semantics and `--force` for `.lnb.env` overwrite (breaking)

Implements the pre-decided breaking semantics from `REWRITE_HANDOFF.md`.

### Behavior changes
- **Literal paths.** `lab-notebook init` (no arg) → `./.lnb`. `lab-notebook init <path>` → exactly `<path>`, with nothing appended (previously `<path>/.lnb`).
- **`.lnb.env` overwrite requires `--force`.** `init` raises an `LnbError` if a `.lnb.env` already exists in the current directory unless `--force` is passed (matches the `template` command's convention). The guard is checked up front, before any notebook directory is created, so a refused run touches nothing.

### Changes
- `cli.py`: literal `target` path; early `.lnb.env` existence guard raising `LnbError`; new `--force` flag on the `init` subparser (replaces the old silent overwrite warning).
- `README.md` + `skill/SKILL.md`: Init/Onboard sections no longer describe `.lnb` appending; the Onboard two-location existence check collapses to a single path (`$LAB_NOTEBOOK_DIR/schema.yaml`) and its env export drops the `/.lnb` suffix; onboard's init now passes `--force` (global setup discards `.lnb.env` anyway).
- `tests/test_cli.py`: existing init tests updated for literal paths and `--force` on re-inits; four new tests cover the literal explicit path, the `./.lnb` default, the `.lnb.env` refuse, and `--force` overwrite.

### Verification
- `uv run pytest -q` → **121 passed** (117 + 4 new).
- Manual CLI smoke: `init mynotes` creates `mynotes/` (no `.lnb`); a second `init` without `--force` exits 1 with the refuse message and leaves `.lnb.env` unchanged; `init other --force` repoints `.lnb.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB