### PR TITLE
feat: US-006 - emit: replace dynamic schema flags with repeatable -f key=value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ lab-notebook init
 # 2. Source .lnb.env (sets LAB_NOTEBOOK_DIR and LAB_NOTEBOOK_WRITER)
 source .lnb.env
 
-# 3. Write an entry (CLI args come from schema.yaml)
+# 3. Write an entry (schema fields are passed with -f KEY=VALUE)
 lab-notebook emit --context maxie/ssl-comparison --type observation \
-    --tags mae,masking \
+    -f tags=mae,masking \
     "MAE with 75% masking spends most capacity on background."
 
 # 4. Query
@@ -144,10 +144,15 @@ Pass `--template` with no value to list available templates. Use
 `--template-path PATH` to load a schema from an arbitrary YAML file on disk
 (mutually exclusive with `--template`).
 
-### `emit --context X --type Y [--artifacts ...] [--field ...] [--extra K=V] "content"`
+### `emit --context X --type Y [--artifacts ...] [-f KEY=VALUE ...] [--extra K=V] "content"`
 
 Write a notebook entry. Required: `--context`, `--type`, content.
-Custom field flags (e.g. `--repo`, `--tags`) are generated from `schema.yaml`.
+Schema fields are passed with the repeatable `-f/--field KEY=VALUE` flag, e.g.
+`-f repo=lab-notebook -f tags=mae,masking` (a `list` field takes a
+comma-separated value). Field names are validated against `schema.yaml` at
+runtime: an unknown name is rejected with a hint to use `--extra` instead, and a
+non-numeric value for an `integer`/`real` field is an error. Because no schema
+is read while building the parser, `emit --help` is identical everywhere.
 
 ### `retract ID --reason "why"`
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -251,8 +251,14 @@ If user picks **A**, ask: "What file should I attach?" Then use the path as `--a
 lab-notebook emit \
     --context <context> --type <type> \
     [--artifacts <path>] \
+    [-f <field>=<value>] \
     "content"
 ```
+
+Schema fields (those declared in `schema.yaml`, e.g. `repo`, `tags`) are passed
+with the repeatable `-f KEY=VALUE` flag; `list` fields take a comma-separated
+value (`-f tags=a,b`). Use `--extra key=value` only for one-off fields not in
+the schema.
 
 **Content**: should be 1-3 sentences with specific numbers, file names, or commit hashes. If you chose option C above, the content is already distilled — use it as-is.
 

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -21,7 +21,6 @@ import sys
 from pathlib import Path
 
 from .schema import (
-    BUILTIN_FIELDS,
     DEFAULT_TEMPLATE,
     LnbError,
     build_sql,
@@ -35,8 +34,6 @@ from .store import (
     LNB_ENV_FILE,
     Notebook,
     _atomic_rebuild,
-    _find_lnb_env,
-    _parse_lnb_env,
     entries_dir,
     get_notebook_dir,
     index_path,
@@ -160,13 +157,18 @@ def cmd_init(args: argparse.Namespace) -> None:
 def cmd_emit(args: argparse.Namespace) -> None:
     nb = Notebook(get_notebook_dir())
 
-    # Collect schema-field values from the parsed args (validation/coercion
-    # happens inside Notebook.emit, not here).
-    fields = {}
-    for name in nb.schema.get("fields", {}):
-        val = getattr(args, name, None)
-        if val is not None:
-            fields[name] = val
+    # Schema-field values come from the static --artifacts built-in plus the
+    # repeatable -f/--field KEY=VALUE flag. Names are validated (and values
+    # coerced) inside Notebook.emit — unknown field -> LnbError suggesting
+    # --extra, bad int/real -> LnbError.
+    fields: dict = {}
+    if args.artifacts is not None:
+        fields["artifacts"] = args.artifacts
+    for item in (args.field or []):
+        key, sep, value = item.partition("=")
+        if not key or not sep:
+            raise LnbError(f"Error: -f/--field must be KEY=VALUE, got '{item}'")
+        fields[key] = value
 
     # Parse repeatable --extra KEY=VALUE strings into a dict; collision checks
     # against declared fields are enforced by Notebook.emit.
@@ -307,35 +309,16 @@ def main() -> None:
     p_emit.add_argument("--type", required=True, help="Entry type (defined in schema.yaml)")
     p_emit.add_argument("--artifacts", default=None,
                         help="Files referenced by this entry (comma-separated paths)")
+    p_emit.add_argument("-f", "--field", action="append", metavar="KEY=VALUE",
+                        help="Schema field value (repeatable; e.g. -f repo=foo -f tags=a,b). "
+                             "Unknown names are rejected — use --extra for undeclared fields.")
     p_emit.add_argument("--extra", action="append", metavar="KEY=VALUE",
                         help="Extra undeclared field (repeatable)")
     p_emit.add_argument("content", help="Entry content (notebook prose)")
-
-    # Dynamically add schema-defined fields if a notebook can be found.
-    # Best-effort: don't crash arg parsing if the path is stale or schema is bad.
-    _parsed_schema = None
-    try:
-        notebook_env = os.environ.get("LAB_NOTEBOOK_DIR")
-        if not notebook_env:
-            env_file = _find_lnb_env()
-            notebook_env = _parse_lnb_env(env_file) if env_file else None
-        if notebook_env:
-            nb_dir = Path(notebook_env)
-            sf = nb_dir / "schema.yaml"
-            if sf.exists():
-                _parsed_schema = load_schema(nb_dir)
-                for name, spec in _parsed_schema.get("fields", {}).items():
-                    if name in BUILTIN_FIELDS:
-                        continue  # already added as a static argument
-                    ftype = spec.get("type", "text")
-                    help_text = f"Schema field ({ftype})"
-                    if ftype == "list":
-                        help_text = f"Schema field ({ftype}, comma-separated)"
-                    p_emit.add_argument(f"--{name}", default=None, help=help_text)
-    except (SystemExit, Exception):
-        pass  # schema loading failed — emit will load schema at runtime
-
-    p_emit.set_defaults(func=cmd_emit, _schema=_parsed_schema)
+    # No schema loading here: the emit parser is static, so --help is identical
+    # regardless of the working directory or LAB_NOTEBOOK_DIR. Schema fields are
+    # passed with -f/--field and validated at runtime in Notebook.emit.
+    p_emit.set_defaults(func=cmd_emit)
 
     # -- retract --
     p_retract = sub.add_parser(

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -390,6 +390,19 @@ class Notebook:
 
         schema_fields = self.schema.get("fields", {})
         fields = fields or {}
+
+        # Reject unknown field names up front. schema_fields already includes the
+        # merged built-ins (e.g. artifacts), so this catches typos and values
+        # meant for the schema that were never declared. Point the caller at
+        # --extra, the escape hatch for undeclared keys.
+        for name in fields:
+            if name not in schema_fields:
+                declared = ", ".join(schema_fields) or "(none)"
+                raise LnbError(
+                    f"Error: unknown field '{name}'. Declared fields: {declared}. "
+                    f"Use --extra {name}=... for an undeclared field."
+                )
+
         for name, spec in schema_fields.items():
             val = fields.get(name)
             if val is not None:
@@ -397,9 +410,19 @@ class Notebook:
                     if isinstance(val, str):
                         val = [v.strip() for v in val.split(",") if v.strip()]
                 elif spec["type"] == "integer":
-                    val = int(val)
+                    try:
+                        val = int(val)
+                    except (TypeError, ValueError):
+                        raise LnbError(
+                            f"Error: field '{name}' expects an integer, got '{val}'"
+                        )
                 elif spec["type"] == "real":
-                    val = float(val)
+                    try:
+                        val = float(val)
+                    except (TypeError, ValueError):
+                        raise LnbError(
+                            f"Error: field '{name}' expects a real number, got '{val}'"
+                        )
             entry[name] = val
 
         reserved_keys = set(CORE_FIELDS) | set(schema_fields.keys()) | {"extra"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,34 +85,34 @@ def custom_notebook(tmp_path, monkeypatch):
 
 
 def make_emit_args(**kwargs):
-    defaults = {
+    """Build an emit Namespace mirroring the argparse surface.
+
+    Schema fields are now passed via the repeatable -f/--field flag rather than
+    dynamic per-field flags, so any kwarg that is not a core/static emit arg is
+    folded into the ``field`` list as ``KEY=VALUE``. Pass ``field=[...]``
+    directly to exercise malformed or explicit -f input.
+    """
+    static = {
         "context": "test/context",
         "type": "observation",
-        "repo": None,
-        "branch": None,
-        "tags": None,
         "artifacts": None,
         "extra": None,
+        "field": None,
         "content": "Test content",
     }
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
+    field = list(kwargs.pop("field", None) or [])
+    for key in [k for k in kwargs if k not in static]:
+        val = kwargs.pop(key)
+        if val is not None:
+            field.append(f"{key}={val}")
+    static.update(kwargs)
+    static["field"] = field or None
+    return argparse.Namespace(**static)
 
 
-def make_custom_emit_args(**kwargs):
-    defaults = {
-        "context": "test/context",
-        "type": "observation",
-        "dataset": None,
-        "gpu_hours": None,
-        "num_nodes": None,
-        "tags": None,
-        "artifacts": None,
-        "extra": None,
-        "content": "Test content",
-    }
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
+# Custom-schema notebooks use different field names (dataset, gpu_hours, ...),
+# but the -f folding above is field-name agnostic, so the builder is identical.
+make_custom_emit_args = make_emit_args
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +471,101 @@ class TestEmit:
         writer_file = entries_dir(notebook) / "test-writer.jsonl"
         line = json.loads(writer_file.read_text().strip())
         assert line["expr"] == "x=y+1"
+
+
+class TestEmitFieldFlag:
+    """Schema fields are passed with repeatable -f/--field KEY=VALUE."""
+
+    def test_field_flag_round_trips_every_type(self, custom_notebook):
+        # text, integer, real, and list (comma-separated) all via -f.
+        cmd_emit(make_custom_emit_args(field=[
+            "dataset=cifar10",
+            "num_nodes=32",
+            "gpu_hours=4.5",
+            "tags=mae,vit, scaling",
+        ], content="All field types via -f"))
+
+        writer_file = entries_dir(custom_notebook) / "test-writer.jsonl"
+        line = json.loads(writer_file.read_text().strip())
+        assert line["dataset"] == "cifar10"          # text
+        assert line["num_nodes"] == 32               # integer (coerced)
+        assert line["gpu_hours"] == 4.5              # real (coerced)
+        # list value lands as a JSON array in the JSONL, not a bare string.
+        assert isinstance(line["tags"], list)
+        assert line["tags"] == ["mae", "vit", "scaling"]
+
+        conn, _, _ = ensure_db(custom_notebook)
+        row = conn.execute(
+            "SELECT dataset, num_nodes, gpu_hours FROM entries"
+        ).fetchone()
+        conn.close()
+        assert row == ("cifar10", 32, 4.5)
+
+    def test_field_flag_repeatable(self, notebook):
+        cmd_emit(make_emit_args(field=["repo=my-repo", "branch=feature/x"],
+                                content="Repeatable -f"))
+        writer_file = entries_dir(notebook) / "test-writer.jsonl"
+        line = json.loads(writer_file.read_text().strip())
+        assert line["repo"] == "my-repo"
+        assert line["branch"] == "feature/x"
+
+    def test_field_flag_artifacts_still_static(self, notebook):
+        # --artifacts remains a static flag (built-in field), not routed via -f.
+        cmd_emit(make_emit_args(artifacts="a.csv, b.png", content="static artifacts"))
+        writer_file = entries_dir(notebook) / "test-writer.jsonl"
+        line = json.loads(writer_file.read_text().strip())
+        assert line["artifacts"] == ["a.csv", "b.png"]
+
+    def test_field_flag_unknown_field_raises_suggesting_extra(self, notebook):
+        with pytest.raises(LnbError) as exc:
+            cmd_emit(make_emit_args(field=["nonesuch=1"], content="bad"))
+        msg = str(exc.value)
+        assert "nonesuch" in msg
+        assert "--extra" in msg
+
+    def test_field_flag_bad_integer_raises(self, custom_notebook):
+        with pytest.raises(LnbError) as exc:
+            cmd_emit(make_custom_emit_args(field=["num_nodes=lots"], content="bad"))
+        assert "integer" in str(exc.value)
+
+    def test_field_flag_bad_real_raises(self, custom_notebook):
+        with pytest.raises(LnbError) as exc:
+            cmd_emit(make_custom_emit_args(field=["gpu_hours=fast"], content="bad"))
+        assert "real" in str(exc.value)
+
+    def test_field_flag_malformed_raises(self, notebook):
+        with pytest.raises(LnbError):
+            cmd_emit(make_emit_args(field=["justkey"], content="bad"))
+
+
+class TestEmitHelpStable:
+    """emit --help must not depend on the working dir or LAB_NOTEBOOK_DIR:
+    the emit parser is static (no schema loading during construction)."""
+
+    def _help_out(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["lab-notebook", "emit", "--help"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+        return capsys.readouterr().out
+
+    def test_help_identical_with_and_without_notebook(
+        self, custom_notebook, tmp_path, monkeypatch, capsys
+    ):
+        # With a discoverable custom notebook (dataset/gpu_hours/... fields):
+        # under the old dynamic-argparse block these would appear as flags.
+        out_with = self._help_out(monkeypatch, capsys)
+        # Strip every notebook signal: the env var and the discovered .lnb.env.
+        monkeypatch.delenv("LAB_NOTEBOOK_DIR", raising=False)
+        (tmp_path / LNB_ENV_FILE).unlink(missing_ok=True)
+        out_without = self._help_out(monkeypatch, capsys)
+
+        assert out_with == out_without
+        assert "--field" in out_with
+        assert "-f" in out_with
+        # No schema-derived flags leak into the static help.
+        assert "--dataset" not in out_with
+        assert "--gpu_hours" not in out_with
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## US-006: emit `-f/--field KEY=VALUE` (breaking)

Schema fields are now passed with a repeatable `-f/--field KEY=VALUE` flag instead of per-field flags that were injected by loading `schema.yaml` during argparse construction.

### Changes
- **cli.py**: removed the dynamic-argparse block (schema loading + blanket `except`) entirely; added a static repeatable `-f/--field KEY=VALUE` flag. `cmd_emit` builds the fields dict from `--artifacts` (static built-in) plus the `-f` values. Dropped now-unused imports (`BUILTIN_FIELDS`, `_find_lnb_env`, `_parse_lnb_env`). `emit --help` no longer depends on the working directory or `LAB_NOTEBOOK_DIR`.
- **store.py** (`Notebook.emit`): rejects an unknown field name with `LnbError` suggesting `--extra`; wraps integer/real coercion so a non-numeric value raises `LnbError`.
- **`--artifacts`** stays a static built-in flag; **`--extra`** is unchanged.
- **README.md / skill/SKILL.md**: emit examples and reference use `-f` for schema fields.

### Tests
- New `TestEmitFieldFlag`: round-trip for every field type via `-f` (text/integer/real/list → JSON array), repeatable `-f`, `--artifacts` still static, unknown field, bad int, bad real, malformed `KEY=VALUE`.
- New `TestEmitHelpStable`: `emit --help` identical with a discoverable custom notebook vs. no notebook at all; no schema-derived flags leak in.
- Test helpers fold schema-field kwargs into the `-f` list.
- `uv run pytest -q`: **129 passed** (was 121).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB