### PR TITLE
feat: US-007 - Add show <id> command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ was forgotten and why. To recover a retracted entry, restore it from a JSONL
 backup and `rebuild` — there is no un-retract command. Any writer may retract
 any entry by id.
 
+### `show ID`
+
+Print one entry in full by id — every core and schema field plus any `--extra`
+values (decoded from their JSON blob) — in a readable key/value layout. Empty
+fields render blank. Errors if the id is not in the index (retracted or never
+existed). Use it after a scan query (`SELECT id, ...`) when a truncated preview
+isn't enough.
+
 ### `sql "query"`
 
 Run raw SQL against the index. Auto-rebuilds if `index.sqlite` is missing.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -325,11 +325,12 @@ lab-notebook contexts
 
 Present a concise answer citing specific entries (timestamp, context, type). Do not dump raw output.
 
-SQL queries use `substr(content,1,80)` by default for scanning. If the truncated preview isn't enough to answer the question, re-run without `substr()` to see the full content:
+SQL queries use `substr(content,1,80)` by default for scanning. If the truncated preview isn't enough, pull the whole entry by id — every core and schema field plus decoded `--extra` values, in a readable key/value layout. Scan with `id` in the select list, then inspect the one you want:
 
 ```bash
 lab-notebook sql \
-  "SELECT ts, type, context, content FROM entries WHERE type='dead-end' ORDER BY ts DESC"
+  "SELECT id, type, substr(content,1,80) FROM entries WHERE type='dead-end' ORDER BY ts DESC"
+lab-notebook show 20260321T143022-a7f2
 ```
 
 **If results are empty**, suggest recovery:

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -4,6 +4,7 @@ Usage:
     lab-notebook init [path] [--template NAME]
     lab-notebook emit --context X --type Y "content"
     lab-notebook retract ID --reason "why"
+    lab-notebook show ID
     lab-notebook sql "SELECT ..."
     lab-notebook search "query"
     lab-notebook schema
@@ -15,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
 import sqlite3
 import sys
@@ -194,6 +196,26 @@ def cmd_retract(args: argparse.Namespace) -> None:
     print(f"[retracted] {args.id}  ({args.reason})")
 
 
+def cmd_show(args: argparse.Namespace) -> None:
+    nb = Notebook(get_notebook_dir())
+    try:
+        entry = nb.get(args.id)
+    finally:
+        nb.close()
+
+    # `extra` is stored as a JSON blob; decode it so its keys print like any
+    # other field. Core and schema columns print first (in table order), then
+    # the decoded --extra keys. None values render as blank.
+    raw_extra = entry.pop("extra", None)
+    extra = json.loads(raw_extra) if raw_extra else {}
+
+    width = max((len(k) for k in list(entry) + list(extra)), default=1)
+    for key, val in entry.items():
+        print(f"{key:<{width}}  {'' if val is None else val}")
+    for key, val in extra.items():
+        print(f"{key:<{width}}  {val}")
+
+
 def cmd_sql(args: argparse.Namespace) -> None:
     nb = Notebook(get_notebook_dir())
     try:
@@ -328,6 +350,11 @@ def main() -> None:
     p_retract.add_argument("--reason", required=True,
                            help="Why this entry is being retracted (recorded in the tombstone)")
     p_retract.set_defaults(func=cmd_retract)
+
+    # -- show --
+    p_show = sub.add_parser("show", help="Print one entry in full by id")
+    p_show.add_argument("id", help="Id of the entry to show")
+    p_show.set_defaults(func=cmd_show)
 
     # -- sql --
     p_sql = sub.add_parser("sql", help="Run a SQL query against the index")

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -477,6 +477,24 @@ class Notebook:
         self._conn, _, _ = ensure_db(self.dir, self.schema)
         return self._conn.execute(sql, params)
 
+    def get(self, entry_id: str) -> dict:
+        """Return one entry as an ordered ``{column: value}`` dict, or raise
+        LnbError if the id is not in the index (retracted or never existed).
+
+        Column order follows the table definition — core fields, then schema
+        fields, then the raw ``extra`` JSON blob — which callers decode for
+        display.
+        """
+        cursor = self.query("SELECT * FROM entries WHERE id = ?", (entry_id,))
+        row = cursor.fetchone()
+        if row is None:
+            raise LnbError(
+                f"Error: entry '{entry_id}' not found "
+                f"(retracted or never existed)"
+            )
+        cols = [d[0] for d in cursor.description]
+        return dict(zip(cols, row))
+
     def close(self) -> None:
         if self._conn is not None:
             self._conn.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from lab_notebook.cli import (
     cmd_retract,
     cmd_search,
     cmd_schema,
+    cmd_show,
     cmd_sql,
     cmd_template,
     main,
@@ -601,6 +602,94 @@ class TestSql:
         out = capsys.readouterr().out
         assert "imagenet" in out
         assert "1 row" in out
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+def make_show_args(entry_id):
+    return argparse.Namespace(id=entry_id)
+
+
+class TestShow:
+    def test_shows_all_core_and_schema_fields(self, notebook, capsys):
+        cmd_emit(make_emit_args(
+            context="demo/ctx", type="observation",
+            artifacts="a.csv,b.png", content="Full content here",
+        ))
+        entry_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        capsys.readouterr()  # clear emit output
+
+        cmd_show(make_show_args(entry_id))
+        out = capsys.readouterr().out
+        # core fields
+        assert entry_id in out
+        assert "writer_id" in out
+        assert "test-writer" in out
+        assert "demo/ctx" in out
+        assert "observation" in out
+        assert "Full content here" in out
+        # built-in schema field (list stored as a JSON array)
+        assert "artifacts" in out
+        assert "a.csv" in out and "b.png" in out
+
+    def test_decodes_extra_json(self, notebook, capsys):
+        cmd_emit(make_emit_args(
+            extra=["foo=bar", "count=3"], content="entry with extras",
+        ))
+        entry_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        capsys.readouterr()
+
+        cmd_show(make_show_args(entry_id))
+        out = capsys.readouterr().out
+        # extra keys are decoded into their own key/value lines, not dumped as
+        # the raw JSON blob.
+        assert "foo" in out and "bar" in out
+        assert "count" in out
+        assert '{"foo"' not in out
+
+    def test_shows_custom_schema_fields(self, custom_notebook, capsys):
+        cmd_emit(make_custom_emit_args(
+            dataset="imagenet", gpu_hours="4.5", tags="mae,vit",
+            content="custom fields entry",
+        ))
+        entry_id = _last_id_in_file(custom_notebook, "test-writer.jsonl")
+        capsys.readouterr()
+
+        cmd_show(make_show_args(entry_id))
+        out = capsys.readouterr().out
+        assert "dataset" in out and "imagenet" in out
+        assert "gpu_hours" in out and "4.5" in out
+        assert "tags" in out and "mae" in out
+
+    def test_nonexistent_id_errors(self, notebook):
+        with pytest.raises(LnbError) as exc:
+            cmd_show(make_show_args("20990101T000000-dead"))
+        assert "not found" in str(exc.value)
+
+    def test_notebook_get_api(self, notebook):
+        # Exercise the Notebook.get API directly (no argparse / cmd layer).
+        cmd_emit(make_emit_args(content="direct api entry"))
+        entry_id = _last_id_in_file(notebook, "test-writer.jsonl")
+
+        nb = Notebook(notebook)
+        try:
+            entry = nb.get(entry_id)
+        finally:
+            nb.close()
+        assert entry["id"] == entry_id
+        assert entry["content"] == "direct api entry"
+        assert entry["context"] == "test/context"
+
+    def test_notebook_get_missing_raises(self, notebook):
+        nb = Notebook(notebook)
+        try:
+            with pytest.raises(LnbError):
+                nb.get("nope-never-existed")
+        finally:
+            nb.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `lab-notebook show <id>`: prints one entry in full — every core and schema field plus decoded `--extra` values — in an aligned key/value layout. Raises `LnbError` if the id is not in the index (retracted or never existed).

## Changes

- **store.py**: new `Notebook.get(entry_id)` returns an ordered `{column: value}` dict from the index (table order: core fields, schema fields, `extra`), raising `LnbError` "not found" if absent.
- **cli.py**: thin `cmd_show` wrapper — `get_notebook_dir → Notebook → get → close`, then formats aligned key/value lines and decodes the `extra` JSON blob into its own key lines (None renders blank). Wired the `show` subparser after `retract`; added `json` import and the docstring usage line.
- **README.md / skill/SKILL.md**: document `show`; the Recall/Summarize section now points at `show <id>` instead of the re-run-without-`substr()` workaround.
- **tests**: `TestShow` (+6) covers full-field output, decoded extra, custom-schema fields, the not-found error, and the `Notebook.get` API directly.

## Verification

`uv run pytest -q` → 135 passed (was 129). `lab-notebook show --help` and `--help` list the new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB