### PR TITLE
feat: US-008 - Widen entry ID random suffix to 4 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Each writer gets their own JSONL file. No merge conflicts.
 
 ```json
 {
-  "id": "20260321T143022-a7f2",
+  "id": "20260321T143022-a7f2c3d1",
   "ts": "2026-03-21T14:30:22",
   "writer_id": "cong",
   "context": "maxie/ssl-comparison",
@@ -246,11 +246,11 @@ an entry itself:
 
 ```json
 {
-  "id": "20260322T091500-c3d1",
+  "id": "20260322T091500-c3d19f4e",
   "ts": "2026-03-22T09:15:00",
   "writer_id": "cong",
   "type": "_retract",
-  "retracts": "20260321T143022-a7f2",
+  "retracts": "20260321T143022-a7f2c3d1",
   "reason": "superseded by a corrected measurement"
 }
 ```

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -330,7 +330,7 @@ SQL queries use `substr(content,1,80)` by default for scanning. If the truncated
 ```bash
 lab-notebook sql \
   "SELECT id, type, substr(content,1,80) FROM entries WHERE type='dead-end' ORDER BY ts DESC"
-lab-notebook show 20260321T143022-a7f2
+lab-notebook show 20260321T143022-a7f2c3d1
 ```
 
 **If results are empty**, suggest recovery:

--- a/src/lab_notebook/schema.py
+++ b/src/lab_notebook/schema.py
@@ -36,7 +36,7 @@ def format_schema_help(schema: dict) -> str:
     fields = schema.get("fields", {})
     lines = ["Table: entries", "--------------"]
     core = [
-        ("id", "TEXT PRIMARY KEY", "e.g. 20260321T143022-a7f2"),
+        ("id", "TEXT PRIMARY KEY", "e.g. 20260321T143022-a7f2c3d1"),
         ("ts", "TEXT NOT NULL", "ISO 8601 local time"),
         ("writer_id", "TEXT NOT NULL", "e.g. cong, agent-claude-01"),
         ("context", "TEXT NOT NULL", "e.g. maxie/ssl-comparison"),

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -89,7 +89,7 @@ def get_writer_id() -> str:
 def generate_id() -> str:
     now = datetime.now()
     ts = now.strftime("%Y%m%dT%H%M%S")
-    rand = secrets.token_hex(2)
+    rand = secrets.token_hex(4)
     return f"{ts}-{rand}"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sqlite3
 from pathlib import Path
@@ -30,6 +31,7 @@ from lab_notebook.store import (
     ensure_db,
     entries_dir,
     flatten_entry,
+    generate_id,
     get_notebook_dir,
     index_path,
 )
@@ -690,6 +692,49 @@ class TestShow:
                 nb.get("nope-never-existed")
         finally:
             nb.close()
+
+
+# ---------------------------------------------------------------------------
+# entry ids
+# ---------------------------------------------------------------------------
+
+
+class TestEntryId:
+    def test_new_id_shape(self):
+        # generate_id() -> compact naive timestamp + '-' + 8 hex chars
+        # (secrets.token_hex(4)).
+        entry_id = generate_id()
+        assert re.fullmatch(r"\d{8}T\d{6}-[0-9a-f]{8}", entry_id), entry_id
+
+    def test_old_format_suffix_still_retracts_and_shows(self, notebook, capsys):
+        # Ids written by older code carry a 4-char (token_hex(2)) suffix.
+        # Nothing parses the suffix, so a hand-written old-format entry must
+        # still ingest, show, and retract like any current entry.
+        old_id = "20240101T120000-ab12"
+        writer_file = entries_dir(notebook) / "legacy-writer.jsonl"
+        writer_file.write_text(json.dumps({
+            "id": old_id,
+            "ts": "2024-01-01T12:00:00",
+            "writer_id": "legacy-writer",
+            "context": "legacy/ctx",
+            "type": "observation",
+            "content": "old-format entry body",
+        }) + "\n")
+
+        # show renders the full entry
+        cmd_show(make_show_args(old_id))
+        out = capsys.readouterr().out
+        assert old_id in out
+        assert "old-format entry body" in out
+
+        # retract removes it from the index
+        cmd_retract(make_retract_args(old_id))
+        conn, _, _ = ensure_db(notebook)
+        try:
+            rows = [r[0] for r in conn.execute("SELECT id FROM entries").fetchall()]
+        finally:
+            conn.close()
+        assert old_id not in rows
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Widens the random suffix on entry ids from `secrets.token_hex(2)` (4 hex chars) to `secrets.token_hex(4)` (8 hex chars), reducing collision probability. Ids now look like `20260321T143022-a7f2c3d1`.

Nothing in the codebase parses the id suffix, so this is fully backward-compatible: existing 4-char-suffix ids remain valid and still show and retract correctly.

## Changes
- `store.py`: `generate_id` uses `secrets.token_hex(4)`.
- `schema.py`: example id in `format_schema_help` widened.
- `README.md` (JSONL Format) and `skill/SKILL.md` (Recall): example ids widened; the retract example's target id kept consistent with the entry it retracts.
- `tests/test_cli.py`: new `TestEntryId` — asserts the new id shape (`^\d{8}T\d{6}-[0-9a-f]{8}$`) and that a hand-written legacy 4-char-suffix entry still shows and retracts.

## Tests
`uv run pytest -q`: 137 passed (was 135; +2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB