### PR TITLE
feat: US-009 - Timezone-aware ISO timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Each writer gets their own JSONL file. No merge conflicts.
 ```json
 {
   "id": "20260321T143022-a7f2c3d1",
-  "ts": "2026-03-21T14:30:22",
+  "ts": "2026-03-21T14:30:22-07:00",
   "writer_id": "cong",
   "context": "maxie/ssl-comparison",
   "type": "observation",
@@ -239,6 +239,16 @@ Each writer gets their own JSONL file. No merge conflicts.
 }
 ```
 
+`ts` is an ISO 8601 timestamp in the writer's local time with an explicit UTC
+offset (`datetime.now().astimezone().isoformat(timespec="seconds")`), e.g.
+`2026-03-21T14:30:22-07:00`. It is stored as TEXT and `ORDER BY ts` sorts
+lexically. Entries written before this format carried a naive timestamp with no
+offset (`2026-03-21T14:30:22`); their date/time prefix still sorts correctly
+against the newer values, so day-level ordering within one machine's history is
+reliable. Cross-timezone ordering of those legacy naive entries is best-effort,
+since a naive value has no offset to normalize against. Entry `id`s keep their
+compact naive form (`YYYYMMDDThhmmss-<hex>`) and are unaffected.
+
 A `retract` appends a tombstone record instead of an entry. Its `type` is
 `_retract`, `retracts` is the id being forgotten, and `reason` is why. It is a
 control record — it deletes its target from the index and is never indexed as
@@ -247,7 +257,7 @@ an entry itself:
 ```json
 {
   "id": "20260322T091500-c3d19f4e",
-  "ts": "2026-03-22T09:15:00",
+  "ts": "2026-03-22T09:15:00-07:00",
   "writer_id": "cong",
   "type": "_retract",
   "retracts": "20260321T143022-a7f2c3d1",

--- a/src/lab_notebook/schema.py
+++ b/src/lab_notebook/schema.py
@@ -37,7 +37,7 @@ def format_schema_help(schema: dict) -> str:
     lines = ["Table: entries", "--------------"]
     core = [
         ("id", "TEXT PRIMARY KEY", "e.g. 20260321T143022-a7f2c3d1"),
-        ("ts", "TEXT NOT NULL", "ISO 8601 local time"),
+        ("ts", "TEXT NOT NULL", "ISO 8601 local time w/ UTC offset"),
         ("writer_id", "TEXT NOT NULL", "e.g. cong, agent-claude-01"),
         ("context", "TEXT NOT NULL", "e.g. maxie/ssl-comparison"),
         ("type", "TEXT NOT NULL", "one of: " + ", ".join(schema["types"])),

--- a/src/lab_notebook/store.py
+++ b/src/lab_notebook/store.py
@@ -381,7 +381,7 @@ class Notebook:
 
         entry = {
             "id": generate_id(),
-            "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "ts": datetime.now().astimezone().isoformat(timespec="seconds"),
             "writer_id": self.writer_id,
             "context": context,
             "type": type,
@@ -459,7 +459,7 @@ class Notebook:
 
         tombstone = {
             "id": generate_id(),
-            "ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "ts": datetime.now().astimezone().isoformat(timespec="seconds"),
             "writer_id": self.writer_id,
             "type": RETRACT_TYPE,
             "retracts": target_id,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -735,6 +736,72 @@ class TestEntryId:
         finally:
             conn.close()
         assert old_id not in rows
+
+
+# ---------------------------------------------------------------------------
+# timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestTimestamp:
+    def test_emit_ts_is_timezone_aware(self, notebook):
+        # New entries carry an offset-bearing ISO 8601 ts, e.g.
+        # 2026-06-10T14:30:22-07:00.
+        cmd_emit(make_emit_args(content="tz-aware entry"))
+        conn, _, _ = ensure_db(notebook)
+        try:
+            ts = conn.execute(
+                "SELECT ts FROM entries WHERE content = ?", ("tz-aware entry",)
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}", ts
+        ), ts
+        # Round-trips through fromisoformat and is genuinely offset-aware.
+        assert datetime.fromisoformat(ts).tzinfo is not None
+
+    def test_order_by_ts_mixes_legacy_naive_and_aware(self, notebook):
+        # Legacy entries carry a naive ts (no offset); new ones carry an
+        # offset-aware ts. Both share the YYYY-MM-DDThh:mm:ss prefix, so a
+        # lexical ORDER BY ts still yields correct day-level ordering when the
+        # two formats are interleaved in one JSONL.
+        writer_file = entries_dir(notebook) / "mixed-writer.jsonl"
+        rows = [
+            ("20260315T143022-aaaa1111", "2026-03-15T14:30:22-07:00", "march aware"),
+            ("20260101T080000-bbbb2222", "2026-01-01T08:00:00", "january naive"),
+            ("20260520T091500-cccc3333", "2026-05-20T09:15:00+02:00", "may aware"),
+            ("20260210T235959-dddd4444", "2026-02-10T23:59:59", "february naive"),
+        ]
+        lines = [
+            json.dumps({
+                "id": entry_id,
+                "ts": ts,
+                "writer_id": "mixed-writer",
+                "context": "mixed/ctx",
+                "type": "observation",
+                "content": content,
+            })
+            for entry_id, ts, content in rows
+        ]
+        writer_file.write_text("\n".join(lines) + "\n")
+
+        conn, _, _ = ensure_db(notebook)
+        try:
+            got = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT content FROM entries ORDER BY ts"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        assert got == [
+            "january naive",
+            "february naive",
+            "march aware",
+            "may aware",
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Entry timestamps (`ts`) are now timezone-aware ISO 8601 with an explicit UTC offset, e.g. `2026-03-21T14:30:22-07:00`, produced via `datetime.now().astimezone().isoformat(timespec="seconds")`.

- Both `ts` sites in `store.py` (`Notebook.emit` and `Notebook.retract`) switched from the naive `strftime("%Y-%m-%dT%H:%M:%S")` to the offset-aware `astimezone().isoformat(...)`.
- Entry `id`s are unchanged — they keep their compact naive `YYYYMMDDThhmmss-<hex>` form. Only `ts` gains the offset.

## Ordering / backward compatibility
`ts` stays TEXT and `ORDER BY ts` stays lexical. Legacy naive values share the `YYYY-MM-DDThh:mm:ss` prefix with the new offset-aware ones, so day-level ordering within one machine's history remains correct even when the two formats are interleaved. Cross-timezone ordering of legacy naive entries is best-effort (a naive value carries no offset to normalize against) — documented in the README JSONL Format section.

## Docs
- `README.md` JSONL Format section documents the new `ts` format and the legacy-naive caveat; the entry and retract examples now show offset-aware `ts`.
- `schema.py` schema-help description for `ts` updated to "ISO 8601 local time w/ UTC offset".
- `skill/SKILL.md` has no `ts` examples, so no change was needed there.

## Tests
New `TestTimestamp` class (`tests/test_cli.py`):
- `test_emit_ts_is_timezone_aware` — asserts the offset-bearing shape and `datetime.fromisoformat(ts).tzinfo is not None`.
- `test_order_by_ts_mixes_legacy_naive_and_aware` — interleaves two naive and two offset-aware entries across distinct days in one JSONL and asserts `ORDER BY ts` yields correct day-level ordering.

`uv run pytest -q`: 139 passed (was 137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017657Fv4r9fFGHazh6D49XB