### PR TITLE
feat: US-010 - show with no id lists all entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,18 @@ was forgotten and why. To recover a retracted entry, restore it from a JSONL
 backup and `rebuild` — there is no un-retract command. Any writer may retract
 any entry by id.
 
-### `show ID`
+### `show [ID]`
 
-Print one entry in full by id — every core and schema field plus any `--extra`
-values (decoded from their JSON blob) — in a readable key/value layout. Empty
-fields render blank. Errors if the id is not in the index (retracted or never
-existed). Use it after a scan query (`SELECT id, ...`) when a truncated preview
-isn't enough.
+With an id, print that entry in full — every core and schema field plus any
+`--extra` values (decoded from their JSON blob) — in a readable key/value
+layout. Empty fields render blank. Errors if the id is not in the index
+(retracted or never existed). Use it after a scan query (`SELECT id, ...`) when
+a truncated preview isn't enough.
+
+With no id, list every entry as a compact table (`id | ts | context | type |
+content`), newest first, one row per entry. Retracted entries are already
+absent from the index, so the listing is live-only. This is the quickest way to
+eyeball the whole notebook or grab an id to pass back to `show`.
 
 ### `sql "query"`
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -343,6 +343,8 @@ lab-notebook sql \
 lab-notebook show 20260321T143022-a7f2c3d1
 ```
 
+To list the whole notebook without writing SQL, run `lab-notebook show` with no id — a compact `id | ts | context | type | content` table of every entry, newest first.
+
 **If results are empty**, suggest recovery:
 
 > Nothing found. Try:

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -240,8 +240,11 @@ def cmd_show(args: argparse.Namespace) -> None:
     # No id: list every live entry as a compact table, newest first. Retracted
     # entries are already absent from the index, so the listing is live-only.
     # The `AS content` alias makes the header read `content` rather than the
-    # raw `substr(...)` expression; the `rowid DESC` tiebreak keeps ordering
-    # stable (newest last-ingested first) when two entries share a timestamp.
+    # raw `substr(...)` expression. `ts` is second-resolution, so `rowid DESC`
+    # is a deterministic tiebreak for entries sharing a timestamp (not a true
+    # sub-second clock: same-second emits across writers order by ingest, which
+    # need not match wall-clock) — this just keeps the output stable and
+    # repeatable rather than planner-dependent.
     if args.id is None:
         nb = Notebook(get_notebook_dir())
         try:

--- a/src/lab_notebook/cli.py
+++ b/src/lab_notebook/cli.py
@@ -4,7 +4,7 @@ Usage:
     lab-notebook init [path] [--template NAME]
     lab-notebook emit --context X --type Y "content"
     lab-notebook retract ID --reason "why"
-    lab-notebook show ID
+    lab-notebook show [ID]
     lab-notebook sql "SELECT ..."
     lab-notebook search "query"
     lab-notebook schema
@@ -237,6 +237,25 @@ def cmd_retract(args: argparse.Namespace) -> None:
 
 
 def cmd_show(args: argparse.Namespace) -> None:
+    # No id: list every live entry as a compact table, newest first. Retracted
+    # entries are already absent from the index, so the listing is live-only.
+    # The `AS content` alias makes the header read `content` rather than the
+    # raw `substr(...)` expression; the `rowid DESC` tiebreak keeps ordering
+    # stable (newest last-ingested first) when two entries share a timestamp.
+    if args.id is None:
+        nb = Notebook(get_notebook_dir())
+        try:
+            cursor = nb.query(
+                "SELECT id, ts, context, type, substr(content, 1, 80) AS content "
+                "FROM entries ORDER BY ts DESC, rowid DESC"
+            )
+            print_table(cursor)
+        except sqlite3.OperationalError as e:
+            raise LnbError(f"SQL error: {e}")
+        finally:
+            nb.close()
+        return
+
     nb = Notebook(get_notebook_dir())
     try:
         entry = nb.get(args.id)
@@ -409,8 +428,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_retract.set_defaults(func=cmd_retract)
 
     # -- show --
-    p_show = sub.add_parser("show", help="Print one entry in full by id")
-    p_show.add_argument("id", help="Id of the entry to show")
+    p_show = sub.add_parser(
+        "show", help="Print one entry in full by id, or list all entries if no id is given")
+    p_show.add_argument(
+        "id", nargs="?", default=None,
+        help="Id of the entry to show; omit to list every entry newest-first")
     p_show.set_defaults(func=cmd_show)
 
     # -- sql --

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,7 +617,7 @@ class TestSql:
 # ---------------------------------------------------------------------------
 
 
-def make_show_args(entry_id):
+def make_show_args(entry_id=None):
     return argparse.Namespace(id=entry_id)
 
 
@@ -698,6 +698,67 @@ class TestShow:
                 nb.get("nope-never-existed")
         finally:
             nb.close()
+
+    def test_no_arg_lists_all_entries(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="alpha one"))
+        cmd_emit(make_emit_args(content="bravo two"))
+        cmd_emit(make_emit_args(content="charlie three"))
+        capsys.readouterr()  # clear emit output
+
+        cmd_show(make_show_args())
+        out = capsys.readouterr().out
+        assert "id|ts|context|type|content" in out
+        assert "alpha one" in out
+        assert "bravo two" in out
+        assert "charlie three" in out
+        assert "(3 rows)" in out
+
+    def test_no_arg_newest_first(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="first alpha"))
+        id_a = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_emit(make_emit_args(content="second bravo"))
+        id_b = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_emit(make_emit_args(content="third charlie"))
+        id_c = _last_id_in_file(notebook, "test-writer.jsonl")
+        capsys.readouterr()  # clear emit output
+
+        cmd_show(make_show_args())
+        out = capsys.readouterr().out
+        # newest-first: C emitted last sorts before B, which sorts before A.
+        assert out.index(id_c) < out.index(id_b) < out.index(id_a)
+
+    def test_no_arg_excludes_retracted(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="keep this entry"))
+        keep_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_emit(make_emit_args(content="drop this entry"))
+        drop_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        cmd_retract(make_retract_args(drop_id))
+        capsys.readouterr()  # clear emit/retract output
+
+        cmd_show(make_show_args())
+        out = capsys.readouterr().out
+        assert keep_id in out
+        assert drop_id not in out
+        assert "(1 row)" in out
+
+    def test_no_arg_empty_notebook(self, notebook, capsys):
+        capsys.readouterr()  # clear any prior output
+
+        cmd_show(make_show_args())
+        out = capsys.readouterr().out
+        assert "(no results)" in out
+        assert "id|ts|context|type" not in out
+
+    def test_id_arg_still_shows_single_entry(self, notebook, capsys):
+        cmd_emit(make_emit_args(content="single entry body"))
+        entry_id = _last_id_in_file(notebook, "test-writer.jsonl")
+        capsys.readouterr()  # clear emit output
+
+        cmd_show(make_show_args(entry_id))
+        out = capsys.readouterr().out
+        assert entry_id in out
+        assert "single entry body" in out
+        assert "writer_id" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`lab-notebook show` now accepts an **optional** id.

- **`show <id>`** — unchanged: prints the one entry in full (key/value layout).
- **`show`** (no id) — lists **every live entry** as a compact table, newest first:

```
id|ts|context|type|content
20260704T030217-59d78649|2026-07-04T03:02:17+00:00|proj/c|dead-end|charlie third
20260704T030217-ca5117b3|2026-07-04T03:02:17+00:00|proj/b|decision|bravo second
20260704T030217-450c3ff4|2026-07-04T03:02:17+00:00|proj/a|observation|alpha first

(3 rows)
```

## How

- `show`'s positional `id` becomes `nargs="?", default=None`.
- `cmd_show` branches on `args.id is None`, running
  `SELECT id, ts, context, type, substr(content,1,80) AS content FROM entries ORDER BY ts DESC, rowid DESC`
  and reusing the existing `print_table`.
- The `AS content` alias makes the header read `content` (not the raw `substr(...)` expression).
- The `rowid DESC` secondary sort keeps ordering stable when entries share a timestamp — verified by a live smoke test where three real emits landed in the same second and still sorted newest-first.
- Retracted entries are already absent from the index, so the listing is live-only for free.

## Design decisions (confirmed with the maintainer)

- **Format:** compact table (`id | ts | context | type | content`), reusing `print_table` for consistency with `sql`/`search`.
- **Order/bound:** newest first (`ORDER BY ts DESC`), **all** live entries, no `LIMIT`.

## Tests

`tests/test_cli.py` `TestShow` gains: lists-all, newest-first, excludes-retracted, empty-notebook (`(no results)`), and an id-still-works regression. Full suite: **167 passed**.

## Docs

`show [ID]` section in README, `show --help`, the module docstring usage block, and the `/lnb` SKILL.md all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)