### PR TITLE
feat(lnb): find→log redesign — JSONL producer, jq is the consumer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - run: sudo apt-get update && sudo apt-get install -y jq
       - run: pip install pytest
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # lnb — minimal lab notebook
 
-A git-tracked, append-only research notebook. **A notebook is not a database to
-configure; it is a directory of JSONL files you scan.** One file, `lnb.py`,
-stdlib only, no index, no schema, no config.
+A git-tracked, append-only research notebook. **lnb is a JSONL producer; `jq`
+is the consumer.** A notebook is not a database to configure; it is a directory
+of JSONL files you scan. One file, `lnb.py`, stdlib only, no index, no schema,
+no config, no dependencies.
 
 > This is the experimental *minimal* line (`dev-min`), distilled from the full
 > `lab-notebook` via a three-persona design review. See `design/`.
@@ -21,17 +22,23 @@ uv tool install .        # or: pipx install .
 lnb note "MAE with 75% masking spends most capacity on background" \
     --type observation @ssl/pretraining tags=mae,masking
 
-# Recall
-lnb find                    # 10 most recent
-lnb find masking            # case-insensitive / regex over content
-lnb find @ssl/pretraining   # filter by context
-lnb find --type dead-end    # filter by type
-lnb find 73caceb5           # a unique id fragment -> that entry in full
-lnb sql "SELECT type, count(*) FROM entries GROUP BY type"
+# Read: `log` emits the WHOLE notebook as JSONL (oldest first); jq selects.
+lnb log                                       # every record, one JSON per line
+lnb log | jq 'select(.type=="decision")'      # filter by type
+lnb log | jq 'select(.content|test("masking";"i"))'   # regex over content
+lnb log | jq 'select(.context=="ssl/pretraining")'    # filter by context
+
+# The ONE canonical LIVE view -- drop tombstones and the entries they retract
+# (also printed by `lnb --help`; naive filters above are fail-open on this):
+lnb log | jq -s 'map(select(.type=="_retract").retracts) as $dead
+  | .[] | select(.type != "_retract" and (.id | IN($dead[]) | not))'
 
 # Retract (logical, append-only): writes a tombstone; the original line stays.
 lnb retract 20260704T163806-73caceb5 --reason "superseded"
 ```
+
+`lnb log` is uncapped and takes no arguments -- for a short view, pipe to
+`| tail` (or `| tac` for most-recent-first).
 
 At the shell, `--type X` / `--context Y` are the safe forms. The `+type` /
 `@context` sigils are DWIM shorthands (`@` is shell-safe; quote `+`/`#` if your
@@ -45,10 +52,14 @@ shell needs it).
 - **Discovery:** `$LNB_DIR`, else the nearest `.lnb/` walking up from the cwd,
   else `./.lnb` is created on the first `note`.
 - **Query:** every read scans every line (milliseconds for a realistic notebook).
-  No index to build, migrate, or invalidate.
-- **Retract:** appends `{"type":"_retract","retracts":<id>,"reason":...}`; readers
-  drop retracted ids. The original entry and the tombstone both remain as the
-  audit trail. No un-retract — restore from a JSONL backup.
+  No index to build, migrate, or invalidate. `log` sorts on the ISO ts *string*
+  and assumes a stable UTC offset (a single-timezone notebook); cross-offset
+  instant ordering is a documented limitation.
+- **Retract:** appends `{"type":"_retract","retracts":<id>,"reason":...}`. `log`
+  emits **every** record, including `_retract` tombstones and the entries they
+  retract — the consumer (jq) computes liveness with the idiom lnb ships in
+  `--help`. The original entry and the tombstone both remain as the audit trail.
+  No un-retract — restore from a JSONL backup.
 - **Append is fail-closed:** one `\n`-terminated write, flushed and `fsync`ed; a
   malformed trailing line is skipped with a warning, never rewritten.
 
@@ -67,5 +78,6 @@ milestone, note`. Any `key=value` becomes an entry field — unvalidated by desi
 ## The honest tradeoff
 
 Every read is O(all entries) and nothing validates fields — fine at 10^4 entries,
-a lie at 10^7. `lnb sql` (a throwaway SQLite rebuilt per call) is the reviewable
-next rung if you outgrow scanning.
+a lie at 10^7. The escalation path when a scan outgrows the terminal is not a
+second query language; it is `lnb log | jq '…'`, and for the full-power case,
+`jq` directly over `.lnb/*.jsonl`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lnb
-description: "Record and recall research notebook entries. Use when the user asks to record an observation, decision, dead-end, question, or milestone, or asks what we've tried / decided / hit. Trigger on: 'note this', 'log this', 'record', 'what have we tried', 'what did we decide', 'search the notebook'."
+description: "Record and recall research notebook entries. Use when the user asks to record an observation, decision, dead-end, question, or milestone, or asks what we've tried / decided / hit. Trigger the WRITE (Note) action on: 'note this', 'log this', 'record'. Trigger the READ (Recall) action on: 'recall', 'what have we tried', 'what did we decide', 'search the notebook'."
 user-invocable: true
 argument-hint: "<note|recall> [text...]"
 ---
@@ -13,10 +13,15 @@ whole notebook as JSONL) — so at this skill layer "log" is never a write; use
 **note**. The CLI (`lnb`) auto-discovers the notebook (nearest `.lnb/` walking
 up, or `$LNB_DIR`) and creates one on the first `note`. No setup step.
 
-Parse the intent of `$ARGUMENTS`: a request to record something (first word
-`note`/`record`, or clearly a new observation/decision/dead-end) → **Note**; a
-request to recall (first word `recall`, or a question about what was tried /
-decided) → **Recall**; if ambiguous, show the two usages below.
+Parse the intent of `$ARGUMENTS`. A request to record something — first word
+`note`/`log`/`record`, a phrasing like "log this"/"note this", or clearly a new
+observation/decision/dead-end → **Note** (the WRITE action; runs `lnb note …`).
+A request to recall — first word `recall`, "what did we / have we …", or a
+question about what was tried / decided → **Recall** (the READ action; runs
+`lnb log | jq …`). If ambiguous, show the two usages below. Note the split:
+the user saying "log this" means WRITE an entry (→ **Note**), whereas the *CLI*
+verb `lnb log` READS the whole notebook (see above) — at this skill layer "log"
+is never the write command, `lnb note` is.
 
 ## Note
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: lnb
-description: "Log and recall research notebook entries. Use when the user asks to record an observation, decision, dead-end, question, or milestone, or asks what we've tried / decided / hit. Trigger on: 'log this', 'note this', 'record', 'what have we tried', 'what did we decide', 'search the notebook'."
+description: "Record and recall research notebook entries. Use when the user asks to record an observation, decision, dead-end, question, or milestone, or asks what we've tried / decided / hit. Trigger on: 'note this', 'log this', 'record', 'what have we tried', 'what did we decide', 'search the notebook'."
 user-invocable: true
-argument-hint: "<log|recall> [text...]"
+argument-hint: "<note|recall> [text...]"
 ---
 
 # Lab Notebook (`/lnb`)
 
-A git-tracked, append-only research notebook. Two verbs: **log** and **recall**.
-The CLI (`lnb`) auto-discovers the notebook (nearest `.lnb/` walking up, or
-`$LNB_DIR`) and creates one on first `log`. No setup step.
+A git-tracked, append-only research notebook. Two skill verbs: **note** (write)
+and **recall** (read). NB: the *CLI* read verb is now `lnb log` (it emits the
+whole notebook as JSONL) — so at this skill layer "log" is never a write; use
+**note**. The CLI (`lnb`) auto-discovers the notebook (nearest `.lnb/` walking
+up, or `$LNB_DIR`) and creates one on the first `note`. No setup step.
 
-Parse the first word of `$ARGUMENTS`: `log` → **Log**, `recall` → **Recall**,
-anything else → show the two usages below.
+Parse the intent of `$ARGUMENTS`: a request to record something (first word
+`note`/`record`, or clearly a new observation/decision/dead-end) → **Note**; a
+request to recall (first word `recall`, or a question about what was tried /
+decided) → **Recall**; if ambiguous, show the two usages below.
 
-## Log
+## Note
 
 Append one entry. **Distill first, then confirm, then write** — the log is
 append-only, so a wrong entry stays as history.
@@ -50,19 +54,28 @@ lnb retract <id> --reason "superseded by a corrected measurement"
 
 ## Recall
 
-Reads are non-destructive — no confirmation needed.
+Reads are non-destructive — no confirmation needed. `lnb log` emits **all**
+entries as JSONL (oldest first, uncapped, including `_retract` tombstones); `jq`
+does every selection.
 
 ```bash
-lnb find                      # 10 most recent, newest last
-lnb find masking ratio        # case-insensitive / regex over content
-lnb find @ssl/pretraining     # filter by context
-lnb find --type dead-end      # (or +dead-end) filter by type
-lnb find a7f2c3d1             # a unique id fragment prints that entry in full
-lnb sql "SELECT type, count(*) FROM entries GROUP BY type"   # aggregates
+lnb log                                              # all entries, oldest first
+lnb log | jq 'select(.type=="dead-end")'             # filter by type
+lnb log | jq 'select(.content|test("masking";"i"))'  # regex over content
+lnb log | jq 'select(.context=="ssl/pretraining")'  # filter by context
+lnb log | jq 'select(.id|test("a7f2c3d1"))'          # fetch one entry by id
+lnb log | jq -r '[.ts,.type,.content]|@tsv'          # project to a table
+lnb log | jq -s 'group_by(.type)|map({(.[0].type):length})'  # aggregate counts
+
+# LIVE view — drop tombstones and the entries they retract (also in `lnb --help`);
+# the plain filters above are FAIL-OPEN and return retracted entries too:
+lnb log | jq -s 'map(select(.type=="_retract").retracts) as $dead
+  | .[] | select(.type != "_retract" and (.id | IN($dead[]) | not))'
 ```
 
-Present a concise answer **citing specific entries** (id, context, type). Don't
-dump raw output. If nothing matches, the CLI already suggests how to broaden —
-relay that.
+`| tail` trims to the most recent; `| tac` flips to newest-first. Present a
+concise answer **citing specific entries** (id, context, type) — don't dump raw
+output. When "live" matters (excluding retracted entries), compose the live-view
+idiom first; a naive type/context filter still returns retracted rows.
 
 $ARGUMENTS

--- a/lnb.py
+++ b/lnb.py
@@ -34,9 +34,6 @@ from datetime import datetime
 
 CORE = ("id", "ts", "writer", "context", "type", "content")  # lnb sets these
 RESERVED = set(CORE) | {"retracts", "reason"}                # writers may not
-# An id fragment: hex/timestamp charset AND at least one digit, so plain
-# hex-lookalike words ("cafe", "dead") stay content searches, not id lookups.
-ID_RE = re.compile(r"^(?=.*\d)[0-9A-Fa-fT:+-]{3,}$")
 KV_RE = re.compile(r"^[A-Za-z_][\w.-]*=\S*$")  # key=value, no whitespace
 USAGE = ('usage: lnb note "content" [+type] [@context] [key=value ...]  |  '
          'log  |  retract <id> --reason "why"')
@@ -272,44 +269,6 @@ def cmd_retract(args):
 def emit_json(rows):
     for e in rows:                      # JSONL: one verbatim record per line
         print(json.dumps(e, ensure_ascii=False))
-
-
-def print_table(rows):
-    for e in rows:
-        content = (e.get("content") or "").replace("\n", " ")
-        if len(content) > 80:
-            content = content[:77] + "..."
-        print(f'{e.get("id",""):<26} {e.get("ts","")[:19]:<19} '
-              f'@{e.get("context",""):<16} +{e.get("type",""):<12} {content}')
-
-
-def show_entry(e):
-    width = max(len(k) for k in list(e.keys()) + list(CORE))
-    for k in CORE:
-        if k in e:
-            print(f"{k:<{width}}  {e[k]}")
-    for k, v in e.items():
-        if k not in CORE:
-            print(f"{k:<{width}}  {v}")
-
-
-def no_matches(rows, terms, context, ctype):
-    """Diagnose -> hypothesize -> prescribe (Conway): say what DOES exist."""
-    q = " ".join(terms)
-    filt = (f" @{context}" if context else "") + (f" +{ctype}" if ctype else "")
-    print(f'no matches for "{q}"{filt} '
-          f'({len(rows)} entries, {len({e.get("context") for e in rows})} contexts).',
-          file=sys.stderr)
-    if context and not any(e.get("context") == context for e in rows):
-        print(f"  contexts present: {vocab(rows, 'context')}", file=sys.stderr)
-    if ctype and not any(e.get("type") == ctype for e in rows):
-        print(f"  types present: {vocab(rows, 'type')}", file=sys.stderr)
-    print("Fewer terms usually helps, or drop the @context/+type filter.",
-          file=sys.stderr)
-
-
-def vocab(rows, field):
-    return ", ".join(sorted({str(e.get(field)) for e in rows if e.get(field)}))
 
 
 def suggest_id(target, rows):

--- a/lnb.py
+++ b/lnb.py
@@ -39,8 +39,7 @@ RESERVED = set(CORE) | {"retracts", "reason"}                # writers may not
 ID_RE = re.compile(r"^(?=.*\d)[0-9A-Fa-fT:+-]{3,}$")
 KV_RE = re.compile(r"^[A-Za-z_][\w.-]*=\S*$")  # key=value, no whitespace
 USAGE = ('usage: lnb note "content" [+type] [@context] [key=value ...]  |  '
-         'find [terms] [@ctx] [+type] [-o json]  |  retract <id> --reason "why"  |  '
-         'sql "SELECT ... FROM entries"')
+         'log  |  retract <id> --reason "why"')
 
 
 # --- notebook discovery & identity ------------------------------------------
@@ -89,12 +88,17 @@ def default_context():
 # --- the single read path & the single write path ---------------------------
 
 def scan(nbdir):
-    """Scan every .lnb/*.jsonl -> (live entries by ts, retracted id set).
+    """Scan every .lnb/*.jsonl -> (all records incl. `_retract` tombstones,
+    ascending by ts string; the retracted id set).
 
-    Fails closed per line: a malformed/partial line is skipped with a warning,
-    never crashes a read and is never rewritten.
+    `log` wants the raw log verbatim; `retract` uses the `retracted` set to
+    own its own liveness guard. Fails closed per line: a malformed/partial line
+    is skipped with a warning, never crashes a read and is never rewritten.
+    Sorts on the ISO ts STRING -- assumes a stable UTC offset (a single-
+    timezone notebook); cross-offset instant ordering is a documented
+    limitation, not a tested guarantee.
     """
-    entries, retracted = [], set()
+    records, retracted = [], set()
     for path in sorted(glob.glob(os.path.join(nbdir, "*.jsonl"))):
         try:
             with open(path, encoding="utf-8") as fh:
@@ -107,16 +111,13 @@ def scan(nbdir):
                     except json.JSONDecodeError:
                         warn(f"skipping malformed line {os.path.basename(path)}:{lineno}")
                         continue
-                    if rec.get("type") == "_retract":
-                        if rec.get("retracts"):
-                            retracted.add(rec["retracts"])
-                    else:
-                        entries.append(rec)
+                    records.append(rec)                        # every record, verbatim
+                    if rec.get("type") == "_retract" and rec.get("retracts"):
+                        retracted.add(rec["retracts"])
         except OSError as e:
             warn(f"cannot read {path}: {e}")
-    live = sorted((e for e in entries if e.get("id") not in retracted),
-                  key=lambda e: e.get("ts", ""))
-    return live, retracted
+    records = sorted(records, key=lambda e: e.get("ts", ""))    # ascending, no reverse=
+    return records, retracted
 
 
 def append(nbdir, record):
@@ -201,52 +202,24 @@ def cmd_note(args):
     print(f'  {content}')
 
 
-def cmd_find(args):
-    terms, ctype, context, _, output = parse(args)
-    if output is not None and output != "json":
-        die(f"unknown output format {output!r} -- the only format is: json")
-    as_json = output == "json"
-    emit = emit_json if as_json else print_table
+def cmd_log(args):
+    """Emit every record as JSONL, ascending by ts -- entries AND `_retract`
+    tombstones, uncapped, verbatim. No filter, no id-lookup, no diagnostics:
+    all selection (including liveness) is jq's job. A stray argument is a
+    fail-closed usage error, never a silent filter."""
+    if args:
+        die(f"log takes no arguments -- it emits every record; filter with jq.\n{USAGE}")
     nbdir = find_notebook()
     if nbdir is None:
         print('no notebook found here. Start one with:  lnb note "..."',
               file=sys.stderr)
         return
-    rows, _ = scan(nbdir)
-    if not rows:
+    records, _ = scan(nbdir)
+    if not records:
         print(f'notebook at {nbdir} is empty -- nothing logged yet.\n'
               f'Start with:  lnb note "..."', file=sys.stderr)
         return
-
-    # A single id-ish term -> that entry in full (unique), or list the matches.
-    if len(terms) == 1 and not context and not ctype and ID_RE.match(terms[0]):
-        hits = [e for e in rows if terms[0] in e.get("id", "")]
-        if len(hits) == 1:
-            return emit(hits) if as_json else show_entry(hits[0])
-        if len(hits) > 1:
-            warn(f"'{terms[0]}' matches {len(hits)} ids:")
-            return emit(hits)
-        # 0 id hits -> fall through and treat it as a content search
-
-    live = rows
-    if context:
-        live = [e for e in live if e.get("context") == context]
-    if ctype:
-        live = [e for e in live if e.get("type") == ctype]
-    if terms:
-        query = " ".join(terms)
-        try:
-            pat = re.compile(query, re.IGNORECASE)
-            live = [e for e in live if pat.search(e.get("content", ""))]
-        except re.error:
-            q = query.lower()
-            live = [e for e in live if q in e.get("content", "").lower()]
-
-    if not live:
-        return no_matches(rows, terms, context, ctype)
-    if not terms and not context and not ctype:
-        live = live[-10:]  # default view: 10 most recent, oldest->newest
-    emit(live)
+    emit_json(records)
 
 
 def cmd_retract(args):
@@ -270,16 +243,23 @@ def cmd_retract(args):
     nbdir = find_notebook()
     if nbdir is None:
         die('no notebook here.  (nothing to retract)')
-    rows, retracted = scan(nbdir)
-    hits = [e for e in rows if e.get("id") == target] or \
-           [e for e in rows if target in e.get("id", "")]
+    records, retracted = scan(nbdir)
+    # scan() now returns tombstones and dead entries too, so retract must own
+    # its liveness: only REAL, still-live entries are retractable candidates.
+    # Both guards matter -- `type != "_retract"` stops a substring `target`
+    # from matching a tombstone's own id ("retract a tombstone"); `id not in
+    # retracted` stops a second tombstone for an already-dead id.
+    live = [e for e in records
+            if e.get("type") != "_retract" and e.get("id") not in retracted]
+    hits = [e for e in live if e.get("id") == target] or \
+           [e for e in live if target in e.get("id", "")]
     if len(hits) > 1:
         die(f"'{target}' is ambiguous -- matches {len(hits)}: "
             f"{', '.join(e['id'] for e in hits)}. Use a longer id.")
     if not hits:
         if any(target == r or target in r for r in retracted):
             die(f"'{target}' is already retracted.")
-        die(f"no entry '{target}'.{suggest_id(target, rows)}")
+        die(f"no entry '{target}'.{suggest_id(target, live)}")
 
     entry = hits[0]
     append(nbdir, new_record(datetime.now().astimezone(),
@@ -358,7 +338,7 @@ def main(argv=None):
         print(__doc__)
         return 0
     cmd, rest = argv[0], argv[1:]
-    dispatch = {"note": cmd_note, "find": cmd_find,
+    dispatch = {"note": cmd_note, "log": cmd_log,
                 "retract": cmd_retract}
     if cmd not in dispatch:
         die(f"unknown command {cmd!r}.\n{USAGE}")

--- a/lnb.py
+++ b/lnb.py
@@ -1,16 +1,31 @@
 #!/usr/bin/env python3
-"""Minimal lab notebook: a git-tracked, append-only log you scan.
+"""Minimal lab notebook: a git-tracked, append-only JSONL log. lnb is the
+PRODUCER; jq is the CONSUMER.
 
 A notebook is not a database to configure. It is a directory of per-writer
-JSONL files under `.lnb/`. Writing appends one JSON line; every read is a scan
-of every line. No index, no schema, no config. When the notebook outgrows a
-scan (~10^5 entries), the reviewable next rung is `lnb sql`, which rebuilds a
-throwaway SQLite from scratch on each call -- never a persistent cache.
+JSONL files under `.lnb/`. `note` appends one well-formed JSON line; `log`
+emits every line; `retract` appends a tombstone. No index, no schema, no
+config. lnb's whole job is making it easy to *write* good JSONL -- reading,
+filtering, projecting and aggregating are jq's job over the stream `log` emits.
 
-    lnb note "content" [+type] [@context] [key=value ...]   # the whole write path
-    lnb find [terms...] [@context] [+type] [-o json]        # the whole read path
-    lnb retract <id> --reason "why"
-    lnb sql "SELECT ... FROM entries"                        # optional escape hatch
+    lnb note "content" [+type] [@context] [key=value ...]   # append one record
+    lnb log     # emit ALL records as JSONL, ascending by ts; jq is the read path
+    lnb retract <id> --reason "why"                         # append a tombstone
+
+`log` is a literal, argument-free emitter: it prints every record verbatim --
+entries AND `_retract` tombstones -- uncapped, oldest first. It runs no filter
+and no id-lookup; ALL selection, including liveness, is jq's. It exits 0 on an
+empty or absent notebook (a stderr onboarding nudge only) and fails closed on
+any argument. Most-recent-first is a consumer step: `| tac` or `| tail`.
+
+    # filter by type -- jq does the selecting:
+    lnb log | jq 'select(.type=="decision")'
+
+    # the one canonical live view -- drop tombstones and the entries they retract:
+    lnb log | jq -s 'map(select(.type=="_retract").retracts) as $dead
+      | .[] | select(.type != "_retract" and (.id | IN($dead[]) | not))'
+    # naive filters are FAIL-OPEN: `lnb log | jq 'select(.type=="decision")'`
+    # returns RETRACTED decisions too -- compose the live view first.
 
 Type defaults to "note"; context defaults to the git repo name. Both are
 overridable: +type / @context sigils (shell-safe), or --type / --context flags
@@ -18,6 +33,9 @@ for scripts. (`#type` is also parsed, but `#` is the shell comment char, so it
 vanishes unquoted -- prefer `+type`.) Any key=value becomes an entry field,
 unvalidated: a typo'd key silently becomes a new field. The notebook trusts its
 writers -- except at the write boundary, which is fail-closed (see cmd_note).
+
+`log` sorts on the ISO ts STRING and assumes a stable UTC offset (a single-
+timezone notebook); cross-offset instant ordering is a documented limitation.
 
 Discovery: $LNB_DIR, else the nearest `.lnb/` walking up from the cwd, else
 `./.lnb` is created on the first `note`. Writer: $LNB_WRITER, else $USER.

--- a/lnb.py
+++ b/lnb.py
@@ -126,6 +126,10 @@ def scan(nbdir):
                     except json.JSONDecodeError:
                         warn(f"skipping malformed line {os.path.basename(path)}:{lineno}")
                         continue
+                    if not isinstance(rec, dict):              # valid JSON, but a
+                        warn(f"skipping non-object line "      # scalar/array is not
+                             f"{os.path.basename(path)}:{lineno}")  # a record -- fail
+                        continue                               # closed, never crash
                     records.append(rec)                        # every record, verbatim
                     if rec.get("type") == "_retract" and rec.get("retracts"):
                         retracted.add(rec["retracts"])

--- a/lnb.py
+++ b/lnb.py
@@ -287,28 +287,6 @@ def cmd_retract(args):
     print(f'retracted {entry["id"]}  ({reason})')
 
 
-def cmd_sql(args):
-    import sqlite3
-    if not args:
-        die('usage: lnb sql "SELECT ... FROM entries"')
-    nbdir = find_notebook()
-    if nbdir is None:
-        die('no notebook here.')
-    rows, _ = scan(nbdir)
-    con = sqlite3.connect(":memory:")
-    con.execute("CREATE TABLE entries (id, ts, writer, context, type, content, extra)")
-    for e in rows:
-        extra = {k: v for k, v in e.items() if k not in CORE}
-        con.execute("INSERT INTO entries VALUES (?,?,?,?,?,?,?)",
-                    (*(e.get(c) for c in CORE), json.dumps(extra) if extra else None))
-    try:
-        cur = con.execute(" ".join(args))
-    except sqlite3.Error as e:
-        die(f"sql error: {e}")
-    for row in cur.fetchall():
-        print("\t".join("" if v is None else str(v) for v in row))
-
-
 # --- rendering, diagnostics & helpers ---------------------------------------
 
 def emit_json(rows):
@@ -381,7 +359,7 @@ def main(argv=None):
         return 0
     cmd, rest = argv[0], argv[1:]
     dispatch = {"note": cmd_note, "find": cmd_find,
-                "retract": cmd_retract, "sql": cmd_sql}
+                "retract": cmd_retract}
     if cmd not in dispatch:
         die(f"unknown command {cmd!r}.\n{USAGE}")
     dispatch[cmd](rest)

--- a/lnb.py
+++ b/lnb.py
@@ -136,25 +136,23 @@ def new_record(now, **fields):
     return rec
 
 
-# --- one arg grammar, shared by note & find ---------------------------------
+# --- one arg grammar, used by note ------------------------------------------
 
 def parse(args):
-    """-> (positionals, ctype, context, extras, output). Sigils +type/#type/@context,
-    flags --type/--context/-o/--output, key=value -> extras, everything else positional."""
-    positionals, ctype, context, extras, output = [], None, None, {}, None
+    """-> (positionals, ctype, context, extras). Sigils +type/#type/@context,
+    flags --type/--context, key=value -> extras, everything else positional."""
+    positionals, ctype, context, extras = [], None, None, {}
     i = 0
     while i < len(args):
         a = args[i]
-        if a in ("--type", "--context", "-o", "--output"):
+        if a in ("--type", "--context"):
             if i + 1 >= len(args):
                 die(f"{a} needs a value.\n{USAGE}")
             i += 1
             if a == "--type":
                 ctype = args[i]
-            elif a == "--context":
-                context = args[i]
             else:
-                output = args[i]
+                context = args[i]
         elif a[:1] in "+#" and len(a) > 1:
             ctype = a[1:]
         elif a[:1] == "@" and len(a) > 1:
@@ -167,15 +165,13 @@ def parse(args):
         else:
             die(f"unexpected argument: {a!r}\n{USAGE}")
         i += 1
-    return positionals, ctype, context, extras, output
+    return positionals, ctype, context, extras
 
 
 # --- commands ---------------------------------------------------------------
 
 def cmd_note(args):
-    positionals, ctype, context, extras, output = parse(args)
-    if output is not None:
-        die("note has no -o/--output; use `find <id> -o json` to fetch a record as JSON")
+    positionals, ctype, context, extras = parse(args)
     content = " ".join(positionals)
     if not content:
         die(f'nothing to log.\n{USAGE}')
@@ -228,7 +224,8 @@ def cmd_retract(args):
             i += 1
             reason = args[i] if i < len(args) else None
         elif a in ("-o", "--output"):
-            die("retract has no -o/--output; use `find <id> -o json` to fetch a record as JSON")
+            die("retract has no -o/--output; it takes an <id> and --reason only. "
+                "To read records, use `lnb log`.")
         elif target is None:
             target = a
         i += 1

--- a/tests/test_lnb.py
+++ b/tests/test_lnb.py
@@ -1,14 +1,25 @@
-"""pytest suite for lnb.py -- the minimal lab notebook CLI.
+"""pytest suite for lnb.py -- the minimal lab notebook CLI (post-redesign).
 
-Invokes the CLI as a subprocess against this worktree's lnb.py. Each test
-gets an isolated notebook via $LNB_DIR pointing into pytest's tmp_path, and
-a fixed $LNB_WRITER="tester" so the per-writer jsonl filename is
-deterministic. Args are passed as a list (no shell), so sigils like
-"#decision" / "+decision" / "@ctx" reach argv literally.
+Three verbs: `note` appends, `log` emits EVERY record as JSONL (ascending by
+ts, incl. `_retract` tombstones, uncapped, verbatim), `retract` appends a
+tombstone. jq is the consumer: all selection -- including liveness -- is jq's
+job, so reads are driven through `lnb log` and, where liveness matters, the
+exact live-view jq recipe lnb ships in `--help`.
+
+Invokes the CLI as a subprocess against this worktree's lnb.py. Each test gets
+an isolated notebook via $LNB_DIR under pytest's tmp_path and a fixed
+$LNB_WRITER="tester" so the per-writer jsonl filename is deterministic. Args
+are passed as a list (no shell), so sigils like "+decision"/"@ctx" reach argv
+literally.
+
+NOTE on ts ordering: `log` sorts on the ISO ts STRING and assumes a stable UTC
+offset (a single-timezone notebook). Cross-offset instant ordering is a
+documented limitation of the design, deliberately NOT tested here.
 """
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +30,19 @@ WORKTREE = Path(__file__).resolve().parent.parent
 LNB_PY = str(WORKTREE / "lnb.py")
 
 NOTED_RE = re.compile(r"^noted (\S+)\s+@(\S*)\s+\+(\S*)", re.MULTILINE)
+
+# The ONE canonical live-view jq recipe. Kept byte-identical to the copy lnb
+# ships in `--help`; test_live_view_jq_idiom_drops_retracted asserts RECIPE is
+# IN the help text AND runs JQ_LIVE_FILTER through real jq, so the shipped copy
+# can never silently rot.
+JQ_LIVE_FILTER = (
+    'map(select(.type=="_retract").retracts) as $dead\n'
+    '      | .[] | select(.type != "_retract" and (.id | IN($dead[]) | not))'
+)
+RECIPE = "lnb log | jq -s '" + JQ_LIVE_FILTER + "'"
+
+HAVE_JQ = shutil.which("jq") is not None
+needs_jq = pytest.mark.skipif(not HAVE_JQ, reason="jq is not installed")
 
 
 def run_lnb(args, cwd=WORKTREE, env=None):
@@ -32,14 +56,22 @@ def run_lnb(args, cwd=WORKTREE, env=None):
     )
 
 
+def run_jq(jq_filter, stdin_text, slurp=False):
+    # -c: compact, one JSON object per line, so results parse line-by-line.
+    # (Only affects formatting; the shipped filter itself is run verbatim.)
+    args = ["jq", "-c"] + (["-s"] if slurp else []) + [jq_filter]
+    return subprocess.run(args, input=stdin_text, capture_output=True,
+                          text=True, timeout=10)
+
+
 @pytest.fixture
 def nb_env(tmp_path):
     """Base env: isolated notebook dir under tmp_path, fixed writer id.
 
     cwd for run_lnb() defaults to WORKTREE (a real git repo) so that the
-    *default context* logic (git rev-parse --show-toplevel) is exercised
-    the same way it would be for a real user, while the notebook itself
-    is safely isolated under tmp_path via $LNB_DIR.
+    *default context* logic (git rev-parse --show-toplevel) is exercised the
+    same way it would be for a real user, while the notebook itself is safely
+    isolated under tmp_path via $LNB_DIR.
     """
     env = os.environ.copy()
     env["LNB_DIR"] = str(tmp_path / "nb")
@@ -62,18 +94,27 @@ def read_entries(env):
     return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
 
 
-# --- note -> find round trip -------------------------------------------------
+def log_objs(env):
+    """`lnb log` -> the emitted records, each stdout line parsed as JSON."""
+    r = run_lnb(["log"], env=env)
+    assert r.returncode == 0, r.stderr
+    return [json.loads(l) for l in r.stdout.splitlines() if l.strip()]
 
-def test_note_find_roundtrip(nb_env):
+
+def n_tombstones(env):
+    return sum(1 for e in read_entries(env) if e.get("type") == "_retract")
+
+
+# --- note -> log round trip --------------------------------------------------
+
+def test_note_log_roundtrip(nb_env):
     marker = "roundtrip-marker-9f8e"
     r = run_lnb(["note", f"testing the {marker} round trip"], env=nb_env)
     assert r.returncode == 0, r.stderr
     info = parse_noted(r.stdout)
 
-    r2 = run_lnb(["find", marker], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    assert info["id"] in r2.stdout
-    assert marker in r2.stdout
+    hit = next(o for o in log_objs(nb_env) if o["id"] == info["id"])
+    assert marker in hit["content"]
 
 
 # --- default context ----------------------------------------------------------
@@ -82,10 +123,14 @@ def test_default_context_is_git_repo_name(nb_env):
     r = run_lnb(["note", "context default check"], env=nb_env)
     assert r.returncode == 0, r.stderr
     info = parse_noted(r.stdout)
-    assert info["context"] == "lab-notebook-min"
+    # default context is the enclosing git repo's dir name; run_lnb's cwd is
+    # WORKTREE, so it's WORKTREE.name -- derived from the filesystem, an
+    # independent cross-check of default_context()'s `git rev-parse` result,
+    # and robust to the worktree's directory name.
+    assert info["context"] == WORKTREE.name
 
     entries = read_entries(nb_env)
-    assert entries[-1]["context"] == "lab-notebook-min"
+    assert entries[-1]["context"] == WORKTREE.name
 
 
 # --- context overrides: @sigil and --context flag ----------------------------
@@ -122,54 +167,44 @@ def test_type_override_flag(nb_env):
     assert parse_noted(r.stdout)["type"] == "milestone"
 
 
-# --- extras persist and surface via find <id> and sql ------------------------
+# --- extras persist and surface as top-level keys in the emitted record ------
 
-def test_extras_persist_and_appear_in_find_and_sql(nb_env):
+def test_extras_persist(nb_env):
     r = run_lnb(["note", "extras persistence test entry", "mae=0.87", "epoch=3"],
-                 env=nb_env)
+                env=nb_env)
     assert r.returncode == 0, r.stderr
     entry_id = parse_noted(r.stdout)["id"]
 
-    # unique id-fragment lookup -> full key/value dump, including extras
-    frag = entry_id.split("-")[-1]
-    r2 = run_lnb(["find", frag], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    assert re.search(r"^mae\s+0\.87\s*$", r2.stdout, re.MULTILINE)
-    assert re.search(r"^epoch\s+3\s*$", r2.stdout, re.MULTILINE)
-
-    # sql: extra column carries a JSON blob with the extras
-    r3 = run_lnb(["sql", f"SELECT extra FROM entries WHERE id = '{entry_id}'"],
-                  env=nb_env)
-    assert r3.returncode == 0, r3.stderr
-    extra = json.loads(r3.stdout.strip())
-    assert extra == {"mae": "0.87", "epoch": "3"}
+    hit = next(o for o in log_objs(nb_env) if o["id"] == entry_id)
+    assert hit["mae"] == "0.87"       # extra surfaced as a top-level key
+    assert hit["epoch"] == "3"
+    # on-disk record matches what `log` emits, verbatim
+    stored = next(e for e in read_entries(nb_env) if e["id"] == entry_id)
+    assert hit == stored
 
 
-# --- retract: removes from find/sql, append-only survives both lines --------
+# --- retract: entry stays visible in log, tombstone appended (contract iii) --
 
-def test_retract_removes_from_find_and_sql_but_keeps_both_lines(nb_env):
+def test_retract_keeps_entry_visible_in_log_and_appends_tombstone(nb_env):
     marker = "retract-target-marker-77"
     r = run_lnb(["note", f"entry to retract {marker}"], env=nb_env)
     assert r.returncode == 0, r.stderr
     entry_id = parse_noted(r.stdout)["id"]
 
-    r_before = run_lnb(["find", marker], env=nb_env)
-    assert entry_id in r_before.stdout
+    assert any(o["id"] == entry_id for o in log_objs(nb_env))
 
     r_retract = run_lnb(["retract", entry_id, "--reason", "no longer valid"],
-                         env=nb_env)
+                        env=nb_env)
     assert r_retract.returncode == 0, r_retract.stderr
 
-    r_after = run_lnb(["find", marker], env=nb_env)
-    assert r_after.returncode == 0
-    assert entry_id not in r_after.stdout
+    # FLIP: after retract, `log` STILL shows the original entry AND the
+    # tombstone (was: excluded). Liveness is the consumer's job now.
+    objs = log_objs(nb_env)
+    assert any(o["id"] == entry_id and o.get("type") != "_retract" for o in objs)
+    assert any(o.get("type") == "_retract" and o.get("retracts") == entry_id
+               for o in objs)
 
-    r_sql = run_lnb(["sql", "SELECT id FROM entries"], env=nb_env)
-    assert r_sql.returncode == 0, r_sql.stderr
-    assert entry_id not in r_sql.stdout.split()
-
-    # append-only: BOTH the original line and the tombstone physically
-    # remain in the jsonl file.
+    # append-only: BOTH the original line and the tombstone physically remain.
     entries = read_entries(nb_env)
     assert len(entries) >= 2
     assert any(e.get("id") == entry_id and e.get("type") != "_retract"
@@ -189,7 +224,7 @@ def test_retract_requires_reason(nb_env):
 def test_retract_bogus_id_exits_nonzero(nb_env):
     run_lnb(["note", "some unrelated entry"], env=nb_env)
     r = run_lnb(["retract", "totallyBogusIdThatDoesNotExist", "--reason", "x"],
-                 env=nb_env)
+                env=nb_env)
     assert r.returncode != 0
     assert r.stderr.strip() != ""
 
@@ -221,35 +256,16 @@ def test_retract_near_match_suggestion_is_id_based(nb_env):
     bogus = entry_id + "Z"
     r2 = run_lnb(["retract", bogus, "--reason", "typo id test"], env=nb_env)
     assert r2.returncode != 0
-    # NB: `bogus` embeds `entry_id` as a literal prefix, and the error message
-    # always echoes the (bogus) target verbatim -- so merely checking
-    # "entry_id in stderr" would trivially pass without a real suggestion.
-    # The actual "did you mean" suggestion phrase is what's being tested here.
+    # `bogus` embeds `entry_id`, and the error echoes the target verbatim, so
+    # "entry_id in stderr" would trivially pass. The "did you mean" suggestion
+    # phrase is what's actually being tested here.
     assert "did you mean" in r2.stderr.lower(), (
         f"expected a 'did you mean {entry_id}' suggestion; stderr was: "
         f"{r2.stderr!r}"
     )
 
 
-# --- unique id-fragment lookup dumps the full entry --------------------------
-
-def test_find_unique_id_fragment_dumps_full_entry(nb_env):
-    r = run_lnb(["note", "fragment lookup entry unique48213", "tag=xyz"],
-                 env=nb_env)
-    assert r.returncode == 0, r.stderr
-    entry_id = parse_noted(r.stdout)["id"]
-    frag = entry_id.split("-")[-1]  # 8-hex random suffix; id-ish per ID_RE
-    assert re.match(r"^[0-9A-Fa-fT-]{3,}$", frag)
-
-    r2 = run_lnb(["find", frag], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    assert re.search(rf"^id\s+{re.escape(entry_id)}\s*$", r2.stdout, re.MULTILINE)
-    assert re.search(r"^content\s+fragment lookup entry unique48213\s*$",
-                      r2.stdout, re.MULTILINE)
-    assert re.search(r"^tag\s+xyz\s*$", r2.stdout, re.MULTILINE)
-
-
-# --- malformed trailing line: skipped with a warning, doesn't crash ---------
+# --- malformed trailing line: skipped with a warning, doesn't crash ----------
 
 def test_malformed_trailing_line_skipped_with_warning(nb_env):
     nb_dir = Path(nb_env["LNB_DIR"])
@@ -265,20 +281,21 @@ def test_malformed_trailing_line_skipped_with_warning(nb_env):
     (nb_dir / "handcrafted.jsonl").write_text(
         json.dumps(good) + "\n" + "{bad json this is not valid\n"
     )
-    r = run_lnb(["find", "marker8675309"], env=nb_env)
+    r = run_lnb(["log"], env=nb_env)
     assert r.returncode == 0
-    assert "marker8675309" in r.stdout
-    assert "malformed" in r.stderr.lower()
+    assert "marker8675309" in r.stdout               # good line survives
+    assert "malformed" in r.stderr.lower()           # bad line diagnosed
     assert "handcrafted.jsonl:2" in r.stderr
 
 
-# --- empty-notebook / no-notebook-found / nothing-found diagnostics --------
+# --- empty-notebook / no-notebook-found onboarding nudges (exit 0) -----------
 
 def test_empty_notebook_diagnostic(nb_env):
-    r = run_lnb(["find"], env=nb_env)
+    r = run_lnb(["log"], env=nb_env)
     assert r.returncode == 0
     assert "empty" in r.stderr.lower()
     assert "lnb note" in r.stderr
+    assert r.stdout.strip() == ""
 
 
 def test_no_notebook_found_diagnostic(tmp_path):
@@ -287,20 +304,25 @@ def test_no_notebook_found_diagnostic(tmp_path):
     env["LNB_WRITER"] = "tester"
     fresh_dir = tmp_path / "isolated_no_notebook"
     fresh_dir.mkdir()
-    r = run_lnb(["find"], cwd=fresh_dir, env=env)
+    r = run_lnb(["log"], cwd=fresh_dir, env=env)
     assert r.returncode == 0
     assert "no notebook found" in r.stderr.lower()
     assert "lnb note" in r.stderr
 
 
-def test_nothing_found_diagnostic(nb_env):
-    run_lnb(["note", "alpha entry one nfmarker"], env=nb_env)
-    run_lnb(["note", "beta entry two nfmarker"], env=nb_env)
-    r = run_lnb(["find", "zzz_no_such_term_zzz"], env=nb_env)
-    assert r.returncode == 0
-    assert "no matches" in r.stderr.lower()
-    assert "2 entries" in r.stderr
-    assert "1 contexts" in r.stderr
+def test_log_empty_and_absent_notebook_still_exit_0(tmp_path):
+    # absent notebook
+    env = os.environ.copy()
+    env.pop("LNB_DIR", None)
+    env["LNB_WRITER"] = "tester"
+    fresh_dir = tmp_path / "absent"
+    fresh_dir.mkdir()
+    assert run_lnb(["log"], cwd=fresh_dir, env=env).returncode == 0
+    # empty (dir exists via $LNB_DIR, no records)
+    env2 = os.environ.copy()
+    env2["LNB_DIR"] = str(tmp_path / "empty_nb")
+    env2["LNB_WRITER"] = "tester"
+    assert run_lnb(["log"], env=env2).returncode == 0
 
 
 # --- note creates ./.lnb from scratch on first write -------------------------
@@ -317,72 +339,228 @@ def test_note_creates_lnb_dir_when_none_exists(tmp_path):
     assert (workdir / ".lnb" / "tester.jsonl").exists()
 
 
-# --- find filters: @context / --context and #type/+type / --type -----------
+# --- log is a literal, filter-free, ascending, uncapped emitter --------------
 
-def test_find_context_filter(nb_env):
-    run_lnb(["note", "ctxA content markerqq", "@ctxA"], env=nb_env)
-    run_lnb(["note", "ctxB content markerqq", "@ctxB"], env=nb_env)
-
-    r = run_lnb(["find", "@ctxA"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    assert "ctxA content markerqq" in r.stdout
-    assert "ctxB content markerqq" not in r.stdout
-
-    r2 = run_lnb(["find", "--context", "ctxB"], env=nb_env)
-    assert "ctxB content markerqq" in r2.stdout
-    assert "ctxA content markerqq" not in r2.stdout
-
-
-def test_find_type_filter(nb_env):
-    run_lnb(["note", "typeA content markerqq", "#typeA"], env=nb_env)
-    run_lnb(["note", "typeB content markerqq", "+typeB"], env=nb_env)
-
-    r = run_lnb(["find", "#typeA"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    assert "typeA content markerqq" in r.stdout
-    assert "typeB content markerqq" not in r.stdout
-
-    r2 = run_lnb(["find", "--type", "typeB"], env=nb_env)
-    assert "typeB content markerqq" in r2.stdout
-    assert "typeA content markerqq" not in r2.stdout
+def test_log_is_filter_free(nb_env):
+    """`log` (no args) emits ALL records regardless of type/context; there is
+    no argument that narrows it."""
+    a = parse_noted(run_lnb(["note", "alpha filterfree", "+decision", "@ctxA"],
+                            env=nb_env).stdout)["id"]
+    b = parse_noted(run_lnb(["note", "beta filterfree", "+note", "@ctxB"],
+                            env=nb_env).stdout)["id"]
+    c = parse_noted(run_lnb(["note", "gamma filterfree", "+deadend", "@ctxC"],
+                            env=nb_env).stdout)["id"]
+    ids = [o["id"] for o in log_objs(nb_env)]
+    assert set(ids) == {a, b, c}
 
 
-# --- default find view: no args -> last 10, oldest-first / newest-last -----
+@pytest.mark.parametrize("stray", [
+    ["decision"], ["@ctx"], ["+type"], ["masking", "ratio"], ["-o", "json"],
+])
+def test_log_stray_arg_is_usage_error(nb_env, stray):
+    """`log` is argument-free and fails CLOSED on any argument (never a silent
+    filter). This is also the anti-gaming lever against keeping stale
+    `-o json`/id/filter behavior alive."""
+    run_lnb(["note", "some entry for stray-arg test"], env=nb_env)
+    r = run_lnb(["log", *stray], env=nb_env)
+    assert r.returncode != 0, f"log {stray!r} must fail closed, not filter"
+    assert r.stdout.strip() == "", "fail-closed: nothing on stdout"
+    assert r.stderr.strip() != ""
 
-def test_find_no_args_default_view_newest_last(nb_env):
+
+def test_log_ascending_order(nb_env):
     ids = []
     for i in range(3):
         r = run_lnb(["note", f"seq marker {i} zzqqqorder"], env=nb_env)
         assert r.returncode == 0, r.stderr
         ids.append(parse_noted(r.stdout)["id"])
 
-    r = run_lnb(["find"], env=nb_env)
+    r = run_lnb(["log"], env=nb_env)
     assert r.returncode == 0, r.stderr
     positions = [r.stdout.index(i) for i in ids]
-    assert positions == sorted(positions), (
-        "expected entries printed oldest-first / newest-last"
-    )
+    assert positions == sorted(positions), "log emits ascending oldest->newest"
 
 
-# --- sql: GROUP BY aggregate --------------------------------------------------
+def test_log_emits_all_ascending_across_writers(nb_env):
+    """Records from two writer files merge and sort ascending by ts across
+    files (`log` re-sorts the whole corpus, so per-file order is irrelevant)."""
+    nb_dir = Path(nb_env["LNB_DIR"])
+    nb_dir.mkdir(parents=True)
+    a = {"id": "20260101T000000-aaaa0001", "ts": "2026-01-01T00:00:00+00:00",
+         "writer": "w1", "context": "c", "type": "note", "content": "first w1"}
+    c = {"id": "20260101T000030-cccc0003", "ts": "2026-01-01T00:00:30+00:00",
+         "writer": "w1", "context": "c", "type": "note", "content": "third w1"}
+    b = {"id": "20260101T000015-bbbb0002", "ts": "2026-01-01T00:00:15+00:00",
+         "writer": "w2", "context": "c", "type": "note", "content": "second w2"}
+    d = {"id": "20260101T000045-dddd0004", "ts": "2026-01-01T00:00:45+00:00",
+         "writer": "w2", "context": "c", "type": "note", "content": "fourth w2"}
+    # neither file is internally interleaved with the other, so a correct merge
+    # requires re-sorting the whole corpus.
+    (nb_dir / "w1.jsonl").write_text(json.dumps(a) + "\n" + json.dumps(c) + "\n")
+    (nb_dir / "w2.jsonl").write_text(json.dumps(b) + "\n" + json.dumps(d) + "\n")
 
-def test_sql_group_by_aggregate(nb_env):
-    run_lnb(["note", "type alpha entry one", "#alpha"], env=nb_env)
-    run_lnb(["note", "type alpha entry two", "#alpha"], env=nb_env)
-    run_lnb(["note", "type beta entry one", "#beta"], env=nb_env)
+    objs = log_objs(nb_env)
+    ts_list = [o["ts"] for o in objs]
+    assert ts_list == sorted(ts_list)
+    assert [o["id"] for o in objs] == [a["id"], b["id"], c["id"], d["id"]]
 
-    r = run_lnb(
-        ["sql", "SELECT type, COUNT(*) FROM entries GROUP BY type ORDER BY type"],
-        env=nb_env,
-    )
+
+def test_log_is_uncapped(nb_env):
+    """>10 entries -> `log` emits ALL of them, with no 'showing N of M' notice
+    anywhere (the removed default-view cap)."""
+    for i in range(15):
+        assert run_lnb(["note", f"uncapped entry number {i}"],
+                       env=nb_env).returncode == 0
+    r = run_lnb(["log"], env=nb_env)
     assert r.returncode == 0, r.stderr
-    rows = [line.split("\t") for line in r.stdout.strip().splitlines()]
-    counts = {t: int(c) for t, c in rows}
-    assert counts["alpha"] == 2
-    assert counts["beta"] == 1
+    objs = [json.loads(l) for l in r.stdout.splitlines() if l.strip()]
+    assert len(objs) == 15
+    combined = (r.stdout + r.stderr).lower()
+    assert "showing" not in combined
+    assert "of 15" not in combined
 
 
-# --- fail-closed write boundary (iter3): a note may not forge system fields --
+def test_log_is_valid_jsonl_only(nb_env):
+    """Every non-empty stdout line independently parses as JSON (valid JSONL);
+    stdout carries ONLY json, no human table header/framing."""
+    for i in range(3):
+        assert run_lnb(["note", f"row {i} jsonlmarker entry"],
+                       env=nb_env).returncode == 0
+    r = run_lnb(["log"], env=nb_env)
+    assert r.returncode == 0, r.stderr
+    lines = [l for l in r.stdout.splitlines() if l.strip()]
+    objs = [json.loads(l) for l in lines]        # raises if any line isn't JSON
+    assert len(objs) == 3
+    assert all(isinstance(o, dict) and "id" in o for o in objs)
+    assert all(l.startswith("{") and l.endswith("}") for l in lines)
+
+
+def test_log_no_truncation(nb_env):
+    """`log` emits `content` verbatim -- no 80-char display truncation."""
+    long_content = "verbatim-marker-vb42 " + "z" * 100
+    r = run_lnb(["note", long_content], env=nb_env)
+    entry_id = parse_noted(r.stdout)["id"]
+
+    hit = next(o for o in log_objs(nb_env) if o["id"] == entry_id)
+    assert hit["content"] == long_content
+    assert len(hit["content"]) > 80              # would have been truncated
+
+
+def test_log_non_ascii_raw(nb_env):
+    """ensure_ascii=False is now the only path: a non-ASCII record round-trips
+    through `log` as raw UTF-8 glyphs, not \\uXXXX escapes."""
+    env = dict(nb_env, PYTHONUTF8="1", PYTHONIOENCODING="utf-8")
+    content = "café ☕ mesure Δμ=0.3 数据"
+    r = run_lnb(["note", content], env=env)
+    assert r.returncode == 0, r.stderr
+    entry_id = parse_noted(r.stdout)["id"]
+
+    r2 = run_lnb(["log"], env=env)
+    assert r2.returncode == 0, r2.stderr
+    line = next(l for l in r2.stdout.splitlines() if entry_id in l)
+    assert "café ☕" in line and "数据" in line   # raw glyphs, present verbatim
+    assert "\\u" not in line                       # NOT ascii-escaped
+    assert json.loads(line)["content"] == content  # lossless round-trip
+
+
+# --- contract iii: log includes retracted entries AND tombstones -------------
+
+def test_log_includes_tombstone_and_retracted(nb_env):
+    """The highest-value pin (RT3, and the FLIP of the old -o-json exclusion):
+    after a retract, `log` emits BOTH the retracted entry AND the
+    `type=='_retract'` tombstone -- the exact OPPOSITE of the pre-redesign
+    behavior. This is what makes the notebook auditable and lets jq compute
+    liveness."""
+    marker = "retract-json-marker-rj9"
+    a = parse_noted(run_lnb(["note", f"first {marker}"], env=nb_env).stdout)["id"]
+    b = parse_noted(run_lnb(["note", f"second {marker}"], env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", a, "--reason", "drop it"],
+                   env=nb_env).returncode == 0
+
+    objs = log_objs(nb_env)
+    ids = [o["id"] for o in objs]
+    assert a in ids                        # retracted entry STILL emitted
+    assert b in ids                        # live sibling emitted
+    assert any(o.get("type") == "_retract" and o.get("retracts") == a
+               for o in objs)              # tombstone emitted
+
+
+def test_retracts_is_scalar_id_string(nb_env):
+    """A `_retract` tombstone's `retracts` is a SCALAR id string, not an array
+    -- the live-view idiom relies on this (an array would silently stop
+    matching in `IN($dead[])` and resurrect retracted rows)."""
+    victim = parse_noted(run_lnb(["note", "scalar retracts target"],
+                                 env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", victim, "--reason", "x"],
+                   env=nb_env).returncode == 0
+    tomb = next(e for e in read_entries(nb_env) if e.get("type") == "_retract")
+    assert isinstance(tomb["retracts"], str)
+    assert tomb["retracts"] == victim
+
+
+def test_tombstone_has_no_context_or_content(nb_env):
+    """A `_retract` tombstone carries exactly id/ts/writer/type/retracts/reason
+    and NO context/content (documents the @tsv/projection-null cost of contract
+    iii -- filter `select(.type!="_retract")` before projecting)."""
+    victim = parse_noted(run_lnb(["note", "tombstone shape target"],
+                                 env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", victim, "--reason", "why-it-died"],
+                   env=nb_env).returncode == 0
+    tomb = next(e for e in read_entries(nb_env) if e.get("type") == "_retract")
+    assert set(tomb) == {"id", "ts", "writer", "type", "retracts", "reason"}
+    assert "context" not in tomb
+    assert "content" not in tomb
+    assert tomb["reason"] == "why-it-died"
+
+
+# --- the shipped live-view recipe: ships in --help AND works under real jq ----
+
+@needs_jq
+def test_live_view_jq_idiom_drops_retracted(nb_env):
+    """Pipe `lnb log` through the EXACT recipe shipped in `--help` (via real
+    jq): the retracted entry and every `_retract` line are dropped, the
+    survivor remains. Asserts BOTH that help contains the recipe verbatim AND
+    that the recipe works, so the shipped copy can never silently rot."""
+    help_out = run_lnb(["--help"], env=nb_env).stdout
+    assert RECIPE in help_out, "the canonical recipe must ship verbatim in --help"
+
+    dead = parse_noted(run_lnb(["note", "to be retracted liveview", "+decision"],
+                               env=nb_env).stdout)["id"]
+    alive = parse_noted(run_lnb(["note", "survivor liveview", "+note"],
+                                env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", dead, "--reason", "superseded"],
+                   env=nb_env).returncode == 0
+
+    log_out = run_lnb(["log"], env=nb_env)
+    assert log_out.returncode == 0, log_out.stderr
+    jq = run_jq(JQ_LIVE_FILTER, log_out.stdout, slurp=True)
+    assert jq.returncode == 0, jq.stderr
+    survivors = [json.loads(l) for l in jq.stdout.splitlines() if l.strip()]
+    ids = [o["id"] for o in survivors]
+    assert alive in ids
+    assert dead not in ids                                   # retracted -> gone
+    assert all(o.get("type") != "_retract" for o in survivors)  # tombstones gone
+
+
+@needs_jq
+def test_naive_filter_keeps_retracted_footgun(nb_env):
+    """The DOCUMENTED fail-open, pinned as a DECISION (not a regression): a
+    naive `log | jq 'select(.type=="decision")'` STILL returns a retracted
+    decision (exit 0). Compose the live view first when you mean live."""
+    dead = parse_noted(run_lnb(["note", "retracted decision footgun", "+decision"],
+                               env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", dead, "--reason", "superseded"],
+                   env=nb_env).returncode == 0
+
+    log_out = run_lnb(["log"], env=nb_env)
+    assert log_out.returncode == 0, log_out.stderr
+    jq = run_jq('select(.type=="decision")', log_out.stdout)
+    assert jq.returncode == 0, jq.stderr
+    ids = [json.loads(l)["id"] for l in jq.stdout.splitlines() if l.strip()]
+    assert dead in ids, "naive filter returns the dead decision -- the footgun"
+
+
+# --- fail-closed write boundary (a note may not forge system records) --------
 
 def test_note_cannot_forge_tombstone_via_extras(nb_env):
     """`note "x" type=_retract retracts=<victim>` must be rejected, not appended
@@ -394,9 +572,8 @@ def test_note_cannot_forge_tombstone_via_extras(nb_env):
         env=nb_env)
     assert attack.returncode != 0
     assert "reserved" in attack.stderr.lower()
-    # victim survives; no tombstone was written
-    r2 = run_lnb(["find", "forgetest"], env=nb_env)
-    assert victim in r2.stdout
+    # victim survives; no tombstone was written (verified via bare `log`)
+    assert any(o["id"] == victim for o in log_objs(nb_env))
     assert not any(e.get("type") == "_retract" for e in read_entries(nb_env))
 
 
@@ -408,8 +585,7 @@ def test_note_cannot_forge_tombstone_via_type_sigil(nb_env):
     attack = run_lnb(
         ["note", "sneaky", "+_retract", f"retracts={victim}"], env=nb_env)
     assert attack.returncode != 0
-    r2 = run_lnb(["find", "forgetest2"], env=nb_env)
-    assert victim in r2.stdout
+    assert any(o["id"] == victim for o in log_objs(nb_env))
 
 
 def test_note_cannot_overwrite_core_fields(nb_env):
@@ -425,7 +601,6 @@ def test_note_with_only_kv_and_no_content_fails_loudly(nb_env):
     r = run_lnb(["note", "tags=mae"], env=nb_env)
     assert r.returncode != 0
     assert "nothing to log" in r.stderr.lower()
-    # nothing was written
     assert not writer_jsonl(nb_env).exists() or read_entries(nb_env) == []
 
 
@@ -437,7 +612,19 @@ def test_note_content_with_equals_and_spaces_is_preserved(nb_env):
     assert "lr" not in entry  # not misparsed as an extra
 
 
+def test_note_rejects_output_flag(nb_env):
+    """`-o/--output` no longer exists: `note ... -o json` is rejected (now via
+    parse()'s generic "unexpected argument"), not a silent no-op."""
+    r = run_lnb(["note", "note with output flag", "-o", "json"], env=nb_env)
+    assert r.returncode != 0
+    assert r.stderr.strip() != ""
+
+
+# --- retract owns its liveness guard (scan() no longer excludes retracted) ---
+
 def test_retract_already_retracted_reports_clearly(nb_env):
+    # NOW MORE LOAD-BEARING: scan() no longer excludes retracted rows, so this
+    # exercises retract's own `id not in retracted` liveness guard directly.
     r = run_lnb(["note", "retract twice target"], env=nb_env)
     victim = parse_noted(r.stdout)["id"]
     assert run_lnb(["retract", victim, "--reason", "first"],
@@ -447,173 +634,76 @@ def test_retract_already_retracted_reports_clearly(nb_env):
     assert "already retracted" in r2.stderr.lower()
 
 
-def test_find_hex_word_without_digit_is_content_search(nb_env):
-    """'dead' is valid hex but has no digit -> stays a content search,
-    never hijacked into an id lookup."""
-    run_lnb(["note", "hit a dead end on augmentation", "+dead-end"], env=nb_env)
-    r = run_lnb(["find", "dead"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    assert "dead end on augmentation" in r.stdout
-
-
-# --- find -o json / --output json (JSONL output mode) ------------------------
-#
-# Contract (see .goal/lnb-json-output.spec.md): stdout carries ONLY compact
-# JSONL -- one verbatim record per live/matched entry; the id-fragment unique
-# path emits ONE plain object (NOT a full-dump wrapper); zero matches emit zero
-# lines at exit 0 with the diagnostic on stderr; retractions are excluded; no
-# 80-char display truncation; unknown formats are rejected loudly; the flag is
-# local to `find`.
-
-def _json_lines(stdout):
-    """The non-empty stdout lines, each parsed as JSON (fails if any isn't)."""
-    lines = [l for l in stdout.splitlines() if l.strip()]
-    return [json.loads(l) for l in lines]
-
-
-def test_find_json_unique_id_is_one_plain_object_with_extras_toplevel(nb_env):
-    """`find <id> -o json` -> exactly ONE line of valid JSON equal to the
-    stored record, with a key=value extra surfaced as a TOP-LEVEL key
-    (invariant shape: one plain object, not a nested/full-dump wrapper)."""
-    r = run_lnb(["note", "json unique fetch marker uj71", "mae=0.9"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    entry_id = parse_noted(r.stdout)["id"]
-
-    r2 = run_lnb(["find", entry_id, "-o", "json"], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    lines = [l for l in r2.stdout.splitlines() if l.strip()]
-    assert len(lines) == 1, f"expected exactly one JSONL line, got: {lines!r}"
-
-    obj = json.loads(lines[0])
-    assert obj["id"] == entry_id
-    assert obj["mae"] == "0.9"            # extra is a top-level typed key
-    # equals the stored record verbatim
-    stored = next(e for e in read_entries(nb_env) if e["id"] == entry_id)
-    assert obj == stored
-
-
-def test_find_json_single_entry_passes_strict_parse(nb_env):
-    """The single-entry json output is a valid JSON document: it survives a
-    strict `python -m json.tool` parse, and is exactly one non-empty line."""
-    r = run_lnb(["note", "json strict parse marker sp42"], env=nb_env)
-    entry_id = parse_noted(r.stdout)["id"]
-
-    r2 = run_lnb(["find", entry_id, "-o", "json"], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    lines = [l for l in r2.stdout.splitlines() if l.strip()]
-    assert len(lines) == 1
-
-    strict = subprocess.run(
-        [sys.executable, "-m", "json.tool"],
-        input=lines[0], capture_output=True, text=True, timeout=10,
-    )
-    assert strict.returncode == 0, strict.stderr
-
-
-def test_find_json_multi_row_is_valid_jsonl_only(nb_env):
-    """Several matches -> every non-empty stdout line independently parses as
-    JSON (valid JSONL), the count equals the matched live entries, and stdout
-    contains ONLY json (no human table header/framing)."""
-    shared = "sharedjsonterm"
-    for i in range(3):
-        assert run_lnb(["note", f"row {i} {shared} entry"],
-                       env=nb_env).returncode == 0
-
-    r = run_lnb(["find", shared, "-o", "json"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    objs = _json_lines(r.stdout)           # raises if any line isn't JSON
-    assert len(objs) == 3
-    assert all(isinstance(o, dict) and "id" in o for o in objs)
-    assert all(shared in o.get("content", "") for o in objs)
-
-
-def test_find_json_empty_result_is_zero_lines_exit0_diag_on_stderr(nb_env):
-    """No match in json mode -> ZERO non-empty stdout lines, exit 0, and the
-    human 'no matches' diagnostic lands on stderr (never on stdout)."""
-    assert run_lnb(["note", "some unrelated json entry"],
+def test_retract_double_is_already_retracted(nb_env):
+    """Re-retracting an already-retracted id -> 'already retracted', and NO
+    second tombstone is appended (retract's `id not in retracted` guard)."""
+    victim = parse_noted(run_lnb(["note", "double retract target"],
+                                 env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", victim, "--reason", "first"],
                    env=nb_env).returncode == 0
+    assert n_tombstones(nb_env) == 1
+    r2 = run_lnb(["retract", victim, "--reason", "second"], env=nb_env)
+    assert r2.returncode != 0
+    assert "already retracted" in r2.stderr.lower()
+    assert n_tombstones(nb_env) == 1, "no second tombstone for a dead id"
 
-    r = run_lnb(["find", "zzz_no_such_term_zzz", "-o", "json"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    assert [l for l in r.stdout.splitlines() if l.strip()] == []
-    assert r.stderr.strip() != ""
 
-
-def test_find_json_excludes_retracted_and_never_emits_tombstone(nb_env):
-    """Retracted entries are excluded from -o json: after retracting one of two
-    entries sharing a marker, the retracted id never appears and no emitted
-    record has type '_retract' (the live sibling still does)."""
-    marker = "retract-json-marker-rj9"
-    a = parse_noted(run_lnb(["note", f"first {marker}"], env=nb_env).stdout)["id"]
-    b = parse_noted(run_lnb(["note", f"second {marker}"], env=nb_env).stdout)["id"]
-    assert run_lnb(["retract", a, "--reason", "drop it"],
+def test_retract_of_tombstone_id_is_no_entry(nb_env):
+    """RT1 -- the single most likely real bug. Retracting a `_retract` row's
+    OWN id must be 'no entry', never a second tombstone. This exercises the
+    `type != "_retract"` guard DISTINCTLY from the already-retracted path: a
+    fresh tombstone's own id is NOT in `retracted`, so a partial guard that
+    only checks `id not in retracted` FAILS this test (it would substring-match
+    the tombstone and append a second tombstone at exit 0)."""
+    victim = parse_noted(run_lnb(["note", "live entry to retract tombstonetest"],
+                                 env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", victim, "--reason", "first"],
                    env=nb_env).returncode == 0
+    assert n_tombstones(nb_env) == 1
 
-    r = run_lnb(["find", marker, "-o", "json"], env=nb_env)
-    assert r.returncode == 0, r.stderr
-    objs = _json_lines(r.stdout)
-    ids = [o["id"] for o in objs]
-    assert a not in ids                    # retracted -> excluded
-    assert b in ids                        # live sibling survives
-    assert all(o.get("type") != "_retract" for o in objs)
+    tomb = next(e for e in read_entries(nb_env) if e.get("type") == "_retract")
+    tomb_id = tomb["id"]
+    assert tomb_id not in ({victim})            # sanity: distinct id
+
+    # attempt to retract the tombstone's own id -- both the full id and its
+    # random suffix (the substring-match attack surface).
+    for target in (tomb_id, tomb_id.split("-")[-1]):
+        r = run_lnb(["retract", target, "--reason", "attack"], env=nb_env)
+        assert r.returncode != 0, f"retract {target!r} (a tombstone id) must fail"
+        assert "no entry" in r.stderr.lower(), r.stderr
+
+    # NO second tombstone was appended by either attempt.
+    assert n_tombstones(nb_env) == 1
 
 
-def test_find_json_unknown_format_rejected_naming_json(nb_env):
-    """An unknown -o value exits nonzero and the guidance names the accepted
-    format 'json'."""
-    run_lnb(["note", "unknown format probe entry"], env=nb_env)
-    r = run_lnb(["find", "probe", "-o", "xml"], env=nb_env)
+def test_suggest_id_never_surfaces_tombstone(nb_env):
+    """A near-miss retract suggests a LIVE id, never a `_retract` tombstone id
+    nor a retracted (dead) id (retract passes `live` to suggest_id). A surfaced
+    tombstone would also print an empty snippet, since tombstones have no
+    content."""
+    live_id = parse_noted(run_lnb(["note", "the live survivor suggesttest"],
+                                  env=nb_env).stdout)["id"]
+    victim = parse_noted(run_lnb(["note", "to retract suggesttest"],
+                                 env=nb_env).stdout)["id"]
+    assert run_lnb(["retract", victim, "--reason", "x"],
+                   env=nb_env).returncode == 0
+    tomb = next(e for e in read_entries(nb_env) if e.get("type") == "_retract")
+
+    # a near-miss typo that is not a substring of any id -> "no entry" + a
+    # "did you mean" suggestion drawn only from live entries.
+    bogus = live_id + "Z"
+    r = run_lnb(["retract", bogus, "--reason", "typo"], env=nb_env)
     assert r.returncode != 0
-    assert "json" in r.stderr.lower()
-
-
-def test_note_rejects_output_flag(nb_env):
-    """`-o/--output` is find-local: `note ... -o json` must be rejected, not a
-    silent no-op."""
-    r = run_lnb(["note", "note with output flag", "-o", "json"], env=nb_env)
-    assert r.returncode != 0
-    assert r.stderr.strip() != ""
-
-
-def test_find_json_long_form_output_flag_equivalent(nb_env):
-    """`--output json` behaves identically to `-o json` for a unique-id fetch:
-    one valid json line."""
-    r = run_lnb(["note", "long form output marker lf33"], env=nb_env)
-    entry_id = parse_noted(r.stdout)["id"]
-
-    r2 = run_lnb(["find", entry_id, "--output", "json"], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    lines = [l for l in r2.stdout.splitlines() if l.strip()]
-    assert len(lines) == 1
-    assert json.loads(lines[0])["id"] == entry_id
-
-
-def test_find_json_no_content_truncation(nb_env):
-    """json mode emits content verbatim -- the human 80-char table truncation
-    must NOT apply."""
-    long_content = "verbatim-marker-vb42 " + "z" * 100
-    r = run_lnb(["note", long_content], env=nb_env)
-    entry_id = parse_noted(r.stdout)["id"]
-
-    r2 = run_lnb(["find", entry_id, "-o", "json"], env=nb_env)
-    assert r2.returncode == 0, r2.stderr
-    obj = json.loads(r2.stdout.splitlines()[0])
-    assert obj["content"] == long_content
-    assert len(obj["content"]) > 80        # would have been truncated in table
-
-
-def test_find_output_flag_missing_value_exits_nonzero(nb_env):
-    """`find <id> -o` with no following value exits nonzero (no IndexError)."""
-    r = run_lnb(["find", "20260101T000000-abcd1234", "-o"], env=nb_env)
-    assert r.returncode != 0
-    assert r.stderr.strip() != ""
+    assert "did you mean" in r.stderr.lower(), r.stderr
+    assert tomb["id"] not in r.stderr, "suggestion surfaced a tombstone id"
+    assert victim not in r.stderr, "suggestion surfaced a retracted (dead) id"
 
 
 def test_retract_rejects_output_flag_and_does_not_retract(nb_env):
-    """`-o/--output` is find-local. `retract <id> -o json` must be rejected
-    LOUDLY (not silently swallowed while the retraction still happens) -- the
-    fail-closed boundary from the iter-2 independent review. The entry must
-    survive."""
+    """`retract <id> -o json` must be rejected LOUDLY (not silently swallowed
+    while the retraction still happens) -- the fail-closed boundary. The entry
+    must survive; verified via bare `log | grep`, NOT `log ... -o json` (which
+    would fail-close on the stray arg and MASK whether the retract happened)."""
     marker = "retract-outflag-marker-rof7"
     r = run_lnb(["note", f"keep me {marker}"], env=nb_env)
     victim = parse_noted(r.stdout)["id"]
@@ -623,25 +713,52 @@ def test_retract_rejects_output_flag_and_does_not_retract(nb_env):
     assert attack.returncode != 0, "retract must reject -o, not swallow it"
     assert attack.stderr.strip() != ""
 
-    # the entry was NOT retracted: it still surfaces, and no tombstone exists
-    r2 = run_lnb(["find", marker, "-o", "json"], env=nb_env)
+    # the entry was NOT retracted: it still surfaces and no tombstone exists.
+    r2 = run_lnb(["log"], env=nb_env)
     assert victim in r2.stdout
     assert not any(e.get("type") == "_retract" for e in read_entries(nb_env))
 
 
-def test_find_json_non_ascii_emitted_raw_not_escaped(nb_env):
-    """ensure_ascii=False (spec point 2): a non-ASCII record round-trips through
-    -o json as raw UTF-8 glyphs, NOT \\uXXXX escapes -- matching append()'s
-    on-disk encoding so the emitted line stays lossless and byte-faithful."""
-    env = dict(nb_env, PYTHONUTF8="1", PYTHONIOENCODING="utf-8")
-    content = "café ☕ mesure Δμ=0.3 数据"
-    r = run_lnb(["note", content], env=env)
-    assert r.returncode == 0, r.stderr
-    entry_id = parse_noted(r.stdout)["id"]
+# --- verb set & help: bare lnb is help, sql/find are unknown -----------------
 
-    r2 = run_lnb(["find", entry_id, "-o", "json"], env=env)
-    assert r2.returncode == 0, r2.stderr
-    line = r2.stdout.splitlines()[0]
-    assert "café ☕" in line and "数据" in line   # raw glyphs, present verbatim
-    assert "\\u" not in line                       # NOT ascii-escaped
-    assert json.loads(line)["content"] == content  # lossless round-trip
+def test_bare_lnb_is_help_not_read(nb_env):
+    """Bare `lnb` prints __doc__ help on stdout (incl. the live-view line),
+    NOT a read of the notebook: no JSONL, exit 0."""
+    run_lnb(["note", "an entry so the notebook is non-empty barehelp"],
+            env=nb_env)
+    r = run_lnb([], env=nb_env)
+    assert r.returncode == 0
+    assert "lnb note" in r.stdout and "lnb log" in r.stdout
+    assert RECIPE in r.stdout
+    assert "barehelp" not in r.stdout                  # not a read of the entry
+
+    def is_record(line):
+        line = line.strip()
+        try:
+            obj = json.loads(line)
+        except Exception:
+            return False
+        return isinstance(obj, dict) and "id" in obj
+    assert not any(is_record(l) for l in r.stdout.splitlines())
+
+
+def test_help_names_three_verbs_and_ships_recipe(nb_env):
+    for flag in (["--help"], ["-h"], ["help"]):
+        r = run_lnb(flag, env=nb_env)
+        assert r.returncode == 0, r.stderr
+        assert "lnb note" in r.stdout
+        assert "lnb log" in r.stdout
+        assert "lnb retract" in r.stdout
+        assert RECIPE in r.stdout
+        # the retired/renamed verbs are gone from help
+        assert "lnb find" not in r.stdout
+        assert "lnb sql" not in r.stdout
+
+
+@pytest.mark.parametrize("cmd", ["sql", "find"])
+def test_retired_and_renamed_commands_are_unknown(nb_env, cmd):
+    """`sql` (retired) and `find` (renamed to `log`) are unknown commands."""
+    run_lnb(["note", "entry for unknown-command test"], env=nb_env)
+    r = run_lnb([cmd, "whatever"], env=nb_env)
+    assert r.returncode != 0
+    assert "unknown command" in r.stderr.lower()

--- a/tests/test_lnb.py
+++ b/tests/test_lnb.py
@@ -41,6 +41,14 @@ JQ_LIVE_FILTER = (
 )
 RECIPE = "lnb log | jq -s '" + JQ_LIVE_FILTER + "'"
 
+# The distinctive core of the live-view recipe. Unlike RECIPE (whose exact
+# indentation is pinned to the --help copy), these two fragments appear verbatim
+# in ALL THREE shipped copies -- lnb.py's docstring/--help, README.md and
+# SKILL.md -- so they pin the README/SKILL copies against drift. Pure text
+# presence, so this runs everywhere (no jq needed).
+RECIPE_CORE = 'select(.type != "_retract" and (.id | IN($dead[]) | not))'
+RECIPE_DEAD_BIND = 'map(select(.type=="_retract").retracts) as $dead'
+
 HAVE_JQ = shutil.which("jq") is not None
 needs_jq = pytest.mark.skipif(not HAVE_JQ, reason="jq is not installed")
 
@@ -286,6 +294,40 @@ def test_malformed_trailing_line_skipped_with_warning(nb_env):
     assert "marker8675309" in r.stdout               # good line survives
     assert "malformed" in r.stderr.lower()           # bad line diagnosed
     assert "handcrafted.jsonl:2" in r.stderr
+
+
+@pytest.mark.parametrize("scalar_line", ["42", "null", "true", '"x"', "[1,2]"])
+def test_scan_skips_non_object_json_line(nb_env, scalar_line):
+    """A line that is VALID json but NOT an object (a scalar/array) must be
+    skipped with a 'skipping non-object line' warning -- never reach rec.get()
+    and crash with an AttributeError. scan() 'fails closed per line', so both
+    reads (`log` here, and `retract`) survive. This test FAILS (traceback,
+    exit != 0) if the isinstance(rec, dict) guard is removed from scan()."""
+    nb_dir = Path(nb_env["LNB_DIR"])
+    nb_dir.mkdir(parents=True)
+    good = {
+        "id": "20260101T000000-deadbeef",
+        "ts": "2026-01-01T00:00:00+00:00",
+        "writer": "handcrafted",
+        "context": "lab-notebook-min",
+        "type": "note",
+        "content": "well formed nonobj-marker-5150",
+    }
+    # good record first, then a valid-JSON-but-non-object line.
+    (nb_dir / "handcrafted.jsonl").write_text(
+        json.dumps(good) + "\n" + scalar_line + "\n"
+    )
+    r = run_lnb(["log"], env=nb_env)
+    assert r.returncode == 0, r.stderr                # exit 0, no crash
+    assert "nonobj-marker-5150" in r.stdout           # good record still emitted
+    assert "skipping non-object line" in r.stderr     # bad line diagnosed
+    assert "handcrafted.jsonl:2" in r.stderr
+    assert "Traceback" not in r.stderr                # NEVER an uncaught traceback
+    assert "AttributeError" not in r.stderr
+    # the non-object was skipped, not emitted: every stdout line is an object.
+    objs = [json.loads(l) for l in r.stdout.splitlines() if l.strip()]
+    assert all(isinstance(o, dict) for o in objs)
+    assert len(objs) == 1
 
 
 # --- empty-notebook / no-notebook-found onboarding nudges (exit 0) -----------
@@ -558,6 +600,31 @@ def test_naive_filter_keeps_retracted_footgun(nb_env):
     assert jq.returncode == 0, jq.stderr
     ids = [json.loads(l)["id"] for l in jq.stdout.splitlines() if l.strip()]
     assert dead in ids, "naive filter returns the dead decision -- the footgun"
+
+
+def test_live_view_recipe_pinned_in_readme_and_skill():
+    """The canonical live-view jq filter ships in THREE places -- lnb.py's
+    docstring/--help (pinned by test_live_view_jq_idiom_drops_retracted),
+    README.md and SKILL.md. Pin the two doc copies too, so none can silently
+    drift from the recipe lnb actually ships. jq-independent (pure text
+    presence), so it runs everywhere."""
+    for doc in ("README.md", "SKILL.md"):
+        text = (WORKTREE / doc).read_text(encoding="utf-8")
+        assert RECIPE_DEAD_BIND in text, (
+            f"{doc} is missing the live-view $dead binding "
+            f"'{RECIPE_DEAD_BIND}' -- it drifted from the shipped recipe")
+        assert RECIPE_CORE in text, (
+            f"{doc} is missing the live-view select core '{RECIPE_CORE}' "
+            f"-- it drifted from the shipped recipe")
+
+
+def test_live_view_recipe_core_ships_in_help(nb_env):
+    """Sanity: the same core fragments this test pins in README/SKILL are the
+    ones lnb ships in --help -- so pinning the docs pins the real recipe, not a
+    fabricated string that exists only in the test."""
+    help_out = run_lnb(["--help"], env=nb_env).stdout
+    assert RECIPE_DEAD_BIND in help_out
+    assert RECIPE_CORE in help_out
 
 
 # --- fail-closed write boundary (a note may not forge system records) --------


### PR DESCRIPTION
## What & why

Implements the converged **`find`→`log` redesign** (design-only PRD `design/lnb-jq-consumer-redesign.md` + the settled deltas in the handoff). The thesis: **lnb is a JSONL producer; `jq` is the consumer.** Every change *net-removes* a concept.

Verb set is now **`note` (append) · `log` (dump) · `retract` (tombstone)**; bare `lnb` = help.

## Changes (all net-subtraction)

- **Rename read verb `find` → `log`.** `log` is a literal, argument-free, **filter-free** emitter: it prints *every* record as JSONL — entries **and** `_retract` tombstones — uncapped, ascending oldest→newest via `sorted()`. All selection (content, context, type, **liveness**) is `jq`'s job. A stray arg to `log` is a fail-closed usage error.
- **Retire `lnb sql` + the `sqlite3` dependency.** The tool is now **stdlib-only** (`dependencies = []`).
- **Remove the 10-entry default-view cap** and its stderr side-channel.
- **Remove `-o json` as a mode** (JSONL is the only output); delete `print_table` / `show_entry`.
- **`scan()` → `(all_records_incl_tombstones ascending, retracted_set)`.** Liveness is no longer computed on read.
- **`retract` re-owns its liveness guard.** One `live` list (`type != "_retract"` **and** `id not in retracted`) feeds both hit branches and `suggest_id` — so retract never targets a tombstone or an already-dead id.
- **Ship one canonical live-view `jq` recipe in `--help`** (Amendment 1) — the producer teaching its consumer, at zero code cost.
- Delete now-orphaned `no_matches` / `vocab` / `ID_RE`; refresh `README.md` and `SKILL.md` (the SKILL read/write `log` collision resolved by hand).

`lnb.py`: **392 → 324 lines**, zero non-stdlib imports.

## The load-bearing correctness point

Because `scan()` now returns tombstones, `retract` can no longer lean on the read path having excluded them. A **partial** guard (checking only `id not in retracted`, forgetting `type != "_retract"`) passes the *entire* rest of the suite yet **still retracts a tombstone**. This is pinned by `test_retract_of_tombstone_id_is_no_entry`, which exercises the tombstone-type path *distinctly* from the already-retracted path. An independent verifier re-derived this from scratch: the test **fails** against a weakened guard and **passes** against this branch.

## Testing

- **50 passed** (`uv run pytest -q`), stdlib-only, jq recipe tests run against real `jq 1.7`.
- The live-view test extracts the recipe **from `--help`** and runs it — so the shipped copy can never silently drift from what's tested.
- End-to-end verified with real bytes: `note` a decision + a note, `retract` the decision → `lnb log` shows all three lines incl. the tombstone; the `--help` live-view idiom leaves only the note; the *naive* `jq 'select(.type=="decision")'` still returns the dead decision (the documented fail-open footgun).

## Notes

- Documented limitation (not engineered around): `scan()` sorts on the raw ISO ts **string**; string order ≠ instant order only across a *changing* UTC offset — harmless for the single-user, single-timezone target.
- Design/planning artifacts live under the git-ignored `.artifacts/` (persona plans, finalized design, red-team findings) — not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpwSWUqhDg9c7N7qKho4Ug
